### PR TITLE
Refresh devkit documentation for the new boundary model

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,13 @@ Important:
 
 ## Writing mods / creating experiences
 
-* Mods and experiences are defined by the stable SDK contracts in **freven-sdk**.
-* Vanilla is the reference experience and uses only the public SDK surface.
+* Neutral platform-shaped authoring uses `freven_mod_api`, `freven_guest_sdk`,
+  and `freven_sdk_types` from **freven-sdk**.
+* Current gameplay/world-stack authoring uses the explicit world-owned
+  `freven_world_api`, `freven_world_guest_sdk`, and `freven_world_sdk_types`
+  surfaces from **freven-sdk**.
+* Vanilla is the first-party reference experience for that explicit world-owned
+  path.
 
 See:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -55,6 +55,8 @@ Tip:
 
 * `init` is safe by default: it **creates missing files** and does not overwrite existing ones.
 * Use `--force` only if you really want to overwrite template files.
+* Dedicated server instances now carry explicit world-owned config sections in
+  `server.toml`: `[world_bootstrap]` and `[world_streaming]`.
 
 ## 4) Run dedicated server + connect a client
 
@@ -88,6 +90,14 @@ Put mods here:
 
 The exact on-disk format depends on runtime type (wasm/external/native).
 See freven-sdk documentation for the current ABI contracts and layouts.
+
+Current authoring ownership:
+
+* use `freven_guest_sdk` / `freven_mod_api` only for neutral platform-shaped
+  declarations
+* use `freven_world_guest_sdk` / `freven_world_api` for gameplay, blocks,
+  actions, providers, and other current world-stack behavior
+* use `freven-vanilla` as the first-party reference for the world-owned path
 
 ## 6) Useful flags
 


### PR DESCRIPTION
## Summary
This PR updates the devkit entry-point documentation to match the new ownership model introduced across the codebase.

It refreshes the top-level README and getting-started guidance to explain the split between neutral SDK surfaces and world-owned SDK surfaces, points readers to the correct crates for each use case, and documents the revised server configuration story for world bootstrap and world streaming.

## Why
Once the code repositories adopt the new boundary model, the devkit needs to describe that model clearly so new users and mod authors start from the right abstractions. This PR is the documentation follow-up that makes the new structure understandable from the outside.

Merge-order note:
Merge last. This is the documentation follow-up after the code repos land.