### PR TITLE
Refresh DevKit docs for the first-class world stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,22 @@ Important:
 
 * The DevKit **archive is read-only**. You can delete and re-extract it anytime.
 * Your instances are safe to keep between updates.
+* Dedicated server `server.toml` keeps world-stack runtime inputs under
+  `[world_bootstrap]` and `[world_streaming]`. On first boot, the server opens
+  or creates `<instance>/worlds/<world_id>/`, writes `world.toml`, and binds
+  that save to the resolved experience.
 
 ## Writing mods / creating experiences
 
 * Neutral platform-shaped authoring uses `freven_mod_api`, `freven_guest_sdk`,
   and `freven_sdk_types` from **freven-sdk**.
-* Current gameplay/world-stack authoring uses the explicit world-owned
+* Current gameplay/world-stack authoring uses the explicit
   `freven_world_api`, `freven_world_guest_sdk`, and `freven_world_sdk_types`
-  surfaces from **freven-sdk**.
-* Vanilla is the first-party reference experience for that explicit world-owned
-  path.
+  surfaces from **freven-sdk** for block/content registration, world
+  queries/mutations, terrain-write worldgen, and world runtime services.
+* Vanilla is the first-party reference experience above that world stack. It
+  owns first-party gameplay policy such as flat worldgen, humanoid controls,
+  break/place ids, and nameplate presentation.
 
 See:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -55,8 +55,9 @@ Tip:
 
 * `init` is safe by default: it **creates missing files** and does not overwrite existing ones.
 * Use `--force` only if you really want to overwrite template files.
-* Dedicated server instances now carry explicit world-owned config sections in
-  `server.toml`: `[world_bootstrap]` and `[world_streaming]`.
+* Dedicated server instances now carry explicit world-stack config sections in
+  `server.toml`: `[world_bootstrap]` selects the world save to open/create and
+  `[world_streaming]` sets join/view/budget policy for world streaming.
 
 ## 4) Run dedicated server + connect a client
 
@@ -95,9 +96,10 @@ Current authoring ownership:
 
 * use `freven_guest_sdk` / `freven_mod_api` only for neutral platform-shaped
   declarations
-* use `freven_world_guest_sdk` / `freven_world_api` for gameplay, blocks,
-  actions, providers, and other current world-stack behavior
-* use `freven-vanilla` as the first-party reference for the world-owned path
+* use `freven_world_guest_sdk` / `freven_world_api` for gameplay, block/content
+  registration, world queries/mutations, terrain-write worldgen, providers,
+  and other current world-stack behavior
+* use `freven-vanilla` as the first-party reference above that world stack
 
 ## 6) Useful flags
 


### PR DESCRIPTION
## Summary
This PR updates the DevKit docs to match the final Stage 02 architecture.

It clarifies:
- how dedicated server instances use `[world_bootstrap]` and `[world_streaming]`
- that first boot opens or creates a world save under `<instance>/worlds/<world_id>/`, writes world metadata, and binds that save to the resolved experience
- that `freven_world_*` authoring surfaces are now for block/content registration, world queries/mutations, terrain-write worldgen, and world runtime services
- that Vanilla is the first-party gameplay layer above the generic world stack and owns first-party policy such as flat worldgen, humanoid controls, break/place ids, and nameplate presentation

This keeps onboarding and generated guidance aligned with the same platform/world/Vanilla ownership map used by the Stage 02 code changes.

## Validation
- [x] Docs-only change reviewed as part of the Stage 02 closeout and forbidden-surface/docs sweep

## Notes for reviewers
This is a documentation sync PR, but it matters because it removes stale guidance that still described the pre-Stage-02 world layer in looser terms.