### PR TITLE
Document bulk block mutation authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Important:
   `freven_world_api`, `freven_world_guest_sdk`, and `freven_world_sdk_types`
   surfaces from **freven-sdk** for block/content registration, world
   queries/mutations, terrain-write worldgen, and world runtime services.
+* Simulation-style runtime block mutation authoring is documented in
+  [`docs/BLOCK_MUTATION_AUTHORING.md`](docs/BLOCK_MUTATION_AUTHORING.md).
 * Vanilla is the first-party reference experience above that world stack. It
   owns first-party gameplay policy such as flat worldgen, humanoid controls,
   break/place ids, and nameplate presentation.

--- a/docs/BLOCK_MUTATION_AUTHORING.md
+++ b/docs/BLOCK_MUTATION_AUTHORING.md
@@ -1,0 +1,230 @@
+# Block Mutation Pipeline v1 authoring
+
+This document describes the DevKit-facing authoring guidance for Block Mutation
+Pipeline v1.
+
+The goal is to make simulation-style mods practical without forcing authors to
+emit huge numbers of scalar block edits every tick.
+
+Examples include:
+
+- cellular automata;
+- infection / spreading blocks;
+- machines and block networks;
+- redstone-like systems;
+- falling-sand-style simulations;
+- large scripted structure edits.
+
+## Ownership
+
+The public contract lives in `freven-sdk`.
+
+DevKit releases pin a compatible engine/sdk/vanilla set. Authors should treat
+the DevKit manifest as the source of truth for which SDK contract is available
+in a given DevKit build.
+
+Runtime block mutations are authoritative server output. They are not client
+visual effects and should not be used as a client-only prediction surface.
+
+## Mutation shapes
+
+Use the smallest shape that honestly represents the edit.
+
+### `SetBlock`
+
+Use scalar `SetBlock` for one-off player actions or very small edits.
+
+Good examples:
+
+- placing one block;
+- breaking one block;
+- toggling one machine output block;
+- applying a tiny number of sparse edits.
+
+### `SetBlocks`
+
+Use `SetBlocks` for compact sparse batches.
+
+Good examples:
+
+- a cellular automata tick where only a small dirty set changed;
+- infection spreading to scattered nearby cells;
+- a machine network changing a bounded list of endpoints.
+
+Keep ordering deterministic. Prefer stable world-position order when building
+the edit list.
+
+### `FillBox`
+
+Use runtime `FillBox` for contiguous rectangular regions.
+
+`FillBox` uses half-open world-cell bounds, matching the worldgen
+`WorldTerrainWrite::FillBox` convention:
+
+~~~text
+min is inclusive
+max is exclusive
+~~~
+
+For example, `min=(0, 64, 0)` and `max=(16, 65, 16)` covers one 16x16 layer.
+
+Prefer `FillBox` over many individual edits for:
+
+- vertical runs;
+- rectangular clears/fills;
+- generated rooms/platforms;
+- block replacement passes over contiguous regions.
+
+## Replace policy
+
+Bulk mutations should be explicit about what they are allowed to replace.
+
+Common patterns:
+
+- only fill air when growing/spreading into empty space;
+- replace only a known previous block id for deterministic simulation updates;
+- use scalar `SetBlock.expected_old` for single-cell compare-and-set style edits.
+
+Avoid broad unconditional replacement unless the mod truly owns that region.
+
+## Budget model
+
+The host validates runtime block mutation output before applying it.
+
+Authors should design against these cost dimensions:
+
+- mutation command count;
+- expanded cell count;
+- touched section count;
+- touched column count;
+- serialized callback result size;
+- runtime call budget / timeout policy.
+
+A small number of commands can still be expensive. For example, one large
+`FillBox` may expand to many cells and many touched sections.
+
+A large number of commands can also be expensive even if each command touches
+one cell.
+
+## Rejection behavior
+
+Over-budget or invalid mutation output must be treated as a recoverable authoring
+/ runtime-output rejection.
+
+The intended contract is:
+
+- no partial apply for a rejected batch;
+- future ticks/lifecycle calls should continue when the rejection is recoverable;
+- diagnostics should identify the budget or validation reason;
+- authors should lower per-tick work, coalesce edits, or split work across ticks.
+
+Do not depend on an over-budget callback disabling the mod. Use explicit mod
+state to track unfinished work and continue later.
+
+## Replication behavior
+
+The server owns replication shape.
+
+Authors should not depend on whether the server sends scalar `BlockUpdate`,
+batched `BlockUpdateBatch`, or a future section/column delta internally.
+
+The stable behavior authors can rely on is:
+
+- applied authoritative block changes become visible to clients;
+- prediction reconciliation is gated by causal terrain revision;
+- large batches are coalesced by the host instead of requiring authors to manage
+  network packet shape.
+
+## Recommended simulation pattern
+
+For simulation-style mods:
+
+1. Keep simulation state in the mod.
+2. Compute a bounded dirty set each tick.
+3. Sort edits deterministically.
+4. Emit `SetBlocks` for sparse dirty edits.
+5. Emit `FillBox` for contiguous runs or regions.
+6. Cap per-tick work in mod config.
+7. Carry remaining work into future ticks instead of emitting an unbounded batch.
+8. Log or expose diagnostics when work is throttled.
+
+Prefer this shape:
+
+~~~text
+simulate -> collect dirty cells -> coalesce runs/boxes -> emit bounded mutations
+~~~
+
+Avoid this shape:
+
+~~~text
+scan whole world every tick -> emit one SetBlock per cell -> hope the host accepts it
+~~~
+
+## Example: sparse dirty cells
+
+Conceptual low-level output shape:
+
+~~~rust
+use freven_block_guest::{BlockEdit, BlockMutation, BlockMutationBatch};
+use freven_block_sdk_types::BlockRuntimeId;
+use freven_world_guest::RuntimeOutput;
+
+let edits = vec![
+    BlockEdit {
+        pos: (10, 64, 10),
+        block_id: BlockRuntimeId(7),
+        expected_old: None,
+    },
+    BlockEdit {
+        pos: (11, 64, 10),
+        block_id: BlockRuntimeId(7),
+        expected_old: None,
+    },
+];
+
+let output = RuntimeOutput {
+    blocks: BlockMutationBatch {
+        mutations: vec![BlockMutation::SetBlocks { edits }],
+    },
+    ..Default::default()
+};
+~~~
+
+Prefer higher-level helpers from `freven_world_guest_sdk` when available for the
+same contract shape.
+
+## Example: contiguous fill
+
+Conceptual low-level output shape:
+
+~~~rust
+use freven_block_guest::{BlockMutation, BlockMutationBatch, BlockReplacePolicy};
+use freven_block_sdk_types::BlockRuntimeId;
+use freven_world_guest::RuntimeOutput;
+
+let output = RuntimeOutput {
+    blocks: BlockMutationBatch {
+        mutations: vec![BlockMutation::FillBox {
+            min: (0, 64, 0),
+            max: (16, 65, 16),
+            block_id: BlockRuntimeId(7),
+            replace: BlockReplacePolicy::OnlyAir,
+        }],
+    },
+    ..Default::default()
+};
+~~~
+
+This fills a 16x16 one-block-high layer, but only where the target cells are air.
+
+## Checklist before reporting a bug
+
+When a simulation mod behaves unexpectedly, include:
+
+- DevKit version and manifest commits;
+- mod runtime type: Wasm, external, native, or compile-time;
+- mutation shapes used: `SetBlock`, `SetBlocks`, `FillBox`;
+- approximate command count and expanded cell count per tick;
+- whether the edits are sparse or contiguous;
+- relevant runtime logs / rejection diagnostics;
+- whether lowering the per-tick budget makes the issue disappear.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -99,6 +99,8 @@ Current authoring ownership:
 * use `freven_world_guest_sdk` / `freven_world_api` for gameplay, block/content
   registration, world queries/mutations, terrain-write worldgen, providers,
   and other current world-stack behavior
+* use [`BLOCK_MUTATION_AUTHORING.md`](BLOCK_MUTATION_AUTHORING.md) for
+  simulation-style runtime block mutation patterns, budgets, and diagnostics
 * use `freven-vanilla` as the first-party reference above that world stack
 
 ## 6) Useful flags


### PR DESCRIPTION
## Summary

Documents Block Mutation Pipeline v1 authoring guidance for simulation-style mods.

This adds DevKit-facing guidance for:

- choosing between scalar `SetBlock`, sparse `SetBlocks`, and rectangular `FillBox`;
- half-open runtime `FillBox` bounds;
- replace-policy authoring patterns;
- mutation cost dimensions: command count, expanded cells, touched sections/columns, result size, and runtime call budget;
- recoverable over-budget rejection behavior;
- server-owned replication shape, including coalesced `BlockUpdateBatch`;
- recommended simulation patterns for cellular automata, infection/spreading blocks, machines, redstone-like systems, and falling-sand-style mods.

## Why

This is the final DevKit/docs step for Block Mutation Pipeline v1.

The SDK and engine-side pieces have already landed:

- SDK bulk mutation contract and guest helpers;
- engine deterministic bulk apply;
- mutation budget summaries;
- causal coalesced replication for large block mutation batches.

This PR makes the feature usable as an author-facing DevKit contract instead of only an internal runtime implementation.

Closes #54.

## Validation

- `git --no-pager diff --check`
- `rg -n 'Block Mutation Pipeline v1|SetBlocks|FillBox|BlockUpdateBatch|simulation-style runtime block mutation|#54' README.md docs/GETTING_STARTED.md docs/BLOCK_MUTATION_AUTHORING.md`