### PR TITLE
Document provider selection authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,10 @@ Include:
 
 * This repository (docs/templates) is under **MIT** (see `LICENSE`).
 * DevKit binaries/content are covered by `LICENSE-DEVKIT.txt` (distributed with the release).
+
+## Authoring references
+
+- [Getting started](docs/GETTING_STARTED.md)
+- [Provider selection authoring](docs/PROVIDER_AUTHORING.md)
+- [Block mutation authoring](docs/BLOCK_MUTATION_AUTHORING.md)
+- [Troubleshooting](docs/TROUBLESHOOTING.md)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -112,3 +112,20 @@ Current authoring ownership:
   * `--quic-forget <host:port>`
   * `--quic-reset-trust`
   * `--quic-accept-new-cert` (use with care)
+
+## Check provider selection
+
+Experiences can explicitly select worldgen, character controller, and client
+control provider keys. Before launching an authored experience, inspect and
+validate those provider defaults:
+
+~~~bash
+./freven_boot providers list --instance instances/player --experience <experience_id>
+./freven_boot providers check --instance instances/player --experience <experience_id>
+./freven_boot providers explain --instance instances/player --experience <experience_id>
+~~~
+
+On Windows, use `freven_boot.exe` with the same `providers` subcommands.
+
+See [Provider selection authoring](PROVIDER_AUTHORING.md) for the full provider
+key contract and side-aware validation rules.

--- a/docs/PROVIDER_AUTHORING.md
+++ b/docs/PROVIDER_AUTHORING.md
@@ -1,0 +1,161 @@
+# Provider selection authoring
+
+Freven provider selection has three separate steps:
+
+1. a mod registers one or more provider keys;
+2. an experience selects provider keys in its defaults;
+3. the runtime validates that selected keys exist for the side that hosts them.
+
+This page documents the author-facing contract for worldgen, character
+controller, and client control providers.
+
+## Provider kinds
+
+Freven currently exposes these provider families:
+
+| Provider kind | Experience default field | Hosted by |
+| --- | --- | --- |
+| Worldgen | `defaults.worldgen` | server |
+| Character controller | `defaults.character_controller` | server and client |
+| Client control provider | `defaults.client_control_provider` | client |
+
+The same experience may be resolved for both server and client. Validation is
+side-aware:
+
+- server validates `worldgen` and `character_controller`;
+- client validates `character_controller` and `client_control_provider`.
+
+This lets a client-only provider default exist without making dedicated server
+startup fail, and lets a server-only worldgen default exist without making a
+network client fail before it connects.
+
+## Selecting explicit provider defaults
+
+Provider defaults live in `experience.toml` or in an
+`experience.stack.toml` layer defaults table.
+
+Example standalone experience:
+
+~~~toml
+schema = 1
+id = "example.experience"
+version = "1.0.0"
+title = "Example Experience"
+
+mods = [
+  "example.providers",
+]
+
+[defaults]
+worldgen = "example.providers:flat"
+character_controller = "example.providers:humanoid"
+client_control_provider = "example.providers:controls"
+~~~
+
+Example stack layer override:
+
+~~~toml
+schema = 1
+id = "example.stack"
+version = "1.0.0"
+title = "Example Stack"
+base = "freven.vanilla"
+
+[[layers]]
+id = "example.stack.providers"
+title = "Provider Override"
+
+[layers.defaults]
+worldgen = "example.providers:flat"
+character_controller = "example.providers:humanoid"
+client_control_provider = "example.providers:controls"
+~~~
+
+Use explicit defaults for production experiences. Implicit fallback still selects
+the first registered provider in that family, but explicit keys are the stable
+long-term contract: they survive provider registration order changes and fail
+honestly when a provider was removed, renamed, or not loaded.
+
+## Inspecting provider catalogs
+
+Use the DevKit provider inspection commands before launching an authored
+experience.
+
+List known provider keys:
+
+~~~bash
+./freven_boot providers list \
+  --instance instances/player \
+  --experience example.experience
+~~~
+
+Validate selected defaults:
+
+~~~bash
+./freven_boot providers check \
+  --instance instances/player \
+  --experience example.experience
+~~~
+
+Explain defaults, hosted sides, and provider ownership:
+
+~~~bash
+./freven_boot providers explain \
+  --instance instances/player \
+  --experience example.experience
+~~~
+
+On Windows:
+
+~~~powershell
+.\freven_boot.exe providers check `
+  --instance instances\player `
+  --experience example.experience
+~~~
+
+## Runtime guest providers
+
+Runtime-loaded guest provider declarations may require launch-time guest
+negotiation before their full provider catalog is known.
+
+In that case `providers check` may report a partial/deferred status instead of a
+full static answer. Launch-time validation still rejects an explicit selected
+default if the hosted runtime side cannot resolve it.
+
+## Failure model
+
+If an explicit provider default names a missing key, Freven fails instead of
+silently falling back to another provider.
+
+For example, this is invalid when no loaded server-side mod registers
+`example.missing:worldgen`:
+
+~~~toml
+[defaults]
+worldgen = "example.missing:worldgen"
+~~~
+
+Run:
+
+~~~bash
+./freven_boot providers check \
+  --instance instances/player \
+  --experience example.experience
+~~~
+
+Expected result: the check reports that the selected worldgen provider default
+did not resolve for the server runtime.
+
+## Recommended authoring loop
+
+1. Add or update provider registration in the mod.
+2. Select the provider key explicitly in the experience defaults.
+3. Run `freven_boot providers list` to confirm the key appears in the catalog.
+4. Run `freven_boot providers check` to validate hosted-side defaults.
+5. Run `freven_boot providers explain` when debugging ownership, side, or
+   deferred runtime-guest behavior.
+6. Launch with `freven_boot play`, `freven_boot serve`, or `freven_boot run`.
+
+Provider selection is part of the public DevKit authoring contract: a provider
+key is not just an implementation detail, it is the stable name that experiences
+and stacks select.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -41,3 +41,19 @@ If the client refuses to connect due to certificate/trust changes:
 - safest: `--quic-forget <host:port>` then reconnect
 - or reset trust store: `--quic-reset-trust`
 - `--quic-accept-new-cert` should be used carefully (a changed cert can be a MITM or server reinstall)
+
+## Provider default does not resolve
+
+If launch or validation reports a missing worldgen, character controller, or
+client control provider, inspect the resolved provider catalog:
+
+~~~bash
+./freven_boot providers explain --instance <instance> --experience <experience_id>
+~~~
+
+Then check that the selected key in `[defaults]` or `[layers.defaults]` exactly
+matches a provider registered by an active mod. Provider default validation is
+side-aware: server validates `worldgen` and `character_controller`, while client
+validates `character_controller` and `client_control_provider`.
+
+See [Provider selection authoring](PROVIDER_AUTHORING.md).


### PR DESCRIPTION
## Summary

Documents the provider selection authoring contract for Freven DevKit users.

This adds:
- provider kind/default mapping for worldgen, character controllers, and client control providers;
- side-aware validation rules for server/client runtime defaults;
- `freven_boot providers list/check/explain` authoring workflow;
- runtime guest/deferred validation notes;
- troubleshooting guidance for missing explicit provider defaults.

This completes the author-facing docs layer after:
- frevenengine/freven-engine#275
- frevenengine/freven-boot#81

Closes frevenengine/freven-sdk#54.

## Validation

- `git --no-pager diff --check`
- `rg -n 'Provider selection authoring|providers list|providers check|providers explain|defaults\.worldgen|defaults\.character_controller|defaults\.client_control_provider' README.md docs`
