### PR TITLE
Polish data-content workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ Include:
 - [Data/content asset workflow](docs/DATA_CONTENT_ASSET_WORKFLOW.md)
 - [Provider selection authoring](docs/PROVIDER_AUTHORING.md)
 - [Block mutation authoring](docs/BLOCK_MUTATION_AUTHORING.md)
-- [Troubleshooting](docs/TROUBLESHOOTING.md)
+- [Troubleshooting](docs/TROUBLESHOOTING.md)\n

--- a/docs/DATA_CONTENT_ASSET_WORKFLOW.md
+++ b/docs/DATA_CONTENT_ASSET_WORKFLOW.md
@@ -319,4 +319,4 @@ This workflow layer is considered present when DevKit users can answer:
 - where do I put referenced resource files?
 - what should never be edited as source?
 - which current commands can I run before launch?
-- which follow-up commands will provide deeper resolved content/asset checks?
+- which follow-up commands will provide deeper resolved content/asset checks?\n

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -96,13 +96,11 @@ The exact on-disk format depends on runtime type (wasm/external/native).
 See freven-sdk documentation for the current ABI contracts and layouts.
 
 Current authoring ownership:
-The data/content asset workflow is documented in
-[`DATA_CONTENT_ASSET_WORKFLOW.md`](DATA_CONTENT_ASSET_WORKFLOW.md). Use it when
-you are shipping authored gameplay definitions, visual content declarations,
-data-only content, or product-owned content. Do not put authored content data in
-active config, generated cache, or save/world state.
 
-
+* use [`DATA_CONTENT_ASSET_WORKFLOW.md`](DATA_CONTENT_ASSET_WORKFLOW.md) when
+  shipping authored gameplay definitions, visual content declarations,
+  data-only content, or product-owned content; do not put authored content
+  data in active config, generated cache, or save/world state
 * use `freven_guest_sdk` / `freven_mod_api` only for neutral platform-shaped
   declarations
 * use `freven_world_guest_sdk` / `freven_world_api` for gameplay, block/content
@@ -137,4 +135,4 @@ validate those provider defaults:
 On Windows, use `freven_boot.exe` with the same `providers` subcommands.
 
 See [Provider selection authoring](PROVIDER_AUTHORING.md) for the full provider
-key contract and side-aware validation rules.
+key contract and side-aware validation rules.\n

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -74,5 +74,4 @@ First identify the boundary that owns the fix:
 - `worlds/` is save/world state, not shipped defaults.
 
 See [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md) before moving
-authored data into config or rebuilding Wasm just to change data files.
-
+authored data into config or rebuilding Wasm just to change data files.\n


### PR DESCRIPTION
## Summary

Polishes the data/content asset workflow docs after #93.

This removes the trailing whitespace warning and makes the Getting Started authoring ownership section read cleanly as one bullet list.

## Validation

- git --no-pager diff --check

Follow-up to #93 / #77.