### PR TITLE
Fix data-content workflow doc newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ Include:
 - [Data/content asset workflow](docs/DATA_CONTENT_ASSET_WORKFLOW.md)
 - [Provider selection authoring](docs/PROVIDER_AUTHORING.md)
 - [Block mutation authoring](docs/BLOCK_MUTATION_AUTHORING.md)
-- [Troubleshooting](docs/TROUBLESHOOTING.md)\n
+- [Troubleshooting](docs/TROUBLESHOOTING.md)

--- a/docs/DATA_CONTENT_ASSET_WORKFLOW.md
+++ b/docs/DATA_CONTENT_ASSET_WORKFLOW.md
@@ -319,4 +319,4 @@ This workflow layer is considered present when DevKit users can answer:
 - where do I put referenced resource files?
 - what should never be edited as source?
 - which current commands can I run before launch?
-- which follow-up commands will provide deeper resolved content/asset checks?\n
+- which follow-up commands will provide deeper resolved content/asset checks?

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -135,4 +135,4 @@ validate those provider defaults:
 On Windows, use `freven_boot.exe` with the same `providers` subcommands.
 
 See [Provider selection authoring](PROVIDER_AUTHORING.md) for the full provider
-key contract and side-aware validation rules.\n
+key contract and side-aware validation rules.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -74,4 +74,4 @@ First identify the boundary that owns the fix:
 - `worlds/` is save/world state, not shipped defaults.
 
 See [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md) before moving
-authored data into config or rebuilding Wasm just to change data files.\n
+authored data into config or rebuilding Wasm just to change data files.


### PR DESCRIPTION
## Summary

Fixes accidental literal backslash-n suffixes introduced by the docs polish follow-up.

## Validation

- git --no-pager diff --check
- rg -n '\\n$' README.md docs || true

Follow-up to #94.