### PR TITLE
Document content-assets check command

### DIFF
--- a/docs/ASSET_PIPELINE_DIAGNOSTICS.md
+++ b/docs/ASSET_PIPELINE_DIAGNOSTICS.md
@@ -20,8 +20,9 @@ This document answers:
 
 ## Non-goals
 
-This document does not implement the final command that walks a resolved
-content/assets graph. That command is tracked by frevenengine/freven-devkit#92.
+This document does not itself implement the command that walks a resolved
+content/assets graph. The current command surface is documented below and is
+implemented by frevenengine/freven-boot#86.
 
 This document does not fix the current `providers check` Material Registry v1
 runtime-path failure. That concrete bug is tracked by frevenengine/freven-devkit#85.
@@ -385,10 +386,36 @@ Those errors should be preserved, but DevKit commands should translate them
 into this author-facing shape instead of exposing only internal build/runtime
 phrasing.
 
+## Command surface
+
+`freven_boot content-assets check` validates the resolved rc10 visual asset load
+plan for the selected experience or stack.
+
+```bash
+./freven_boot content-assets check --instance <instance> --experience <experience_id>
+```
+
+Use it when authored texture, material, model, shader/effect, block visual, or
+content patch data does not load.
+
+`freven_boot content-assets explain` prints the resolved graph:
+
+```bash
+./freven_boot content-assets explain --instance <instance> --experience <experience_id>
+```
+
+The explain output includes selected content layers, effective assets,
+dependency edges, shadowed overrides, internal slots, and the load-plan
+fingerprint.
+
+This command is the preferred pre-launch path for asset/content validation. Do
+not route visual asset diagnosis through `providers check` unless you are
+specifically debugging provider declarations.
+
 ## Relationship to other rc10 DevKit issues
 
-- frevenengine/freven-devkit#92 should implement the command that emits these
-  diagnostics for resolved content/assets load plans.
+- frevenengine/freven-boot#86 implements the current `content-assets check` and
+  `content-assets explain` command surface for resolved visual load plans.
 - frevenengine/freven-devkit#85 should fix the current `providers check`
   Material Registry v1 failure path.
 - frevenengine/freven-devkit#88 should display the same diagnostic fields in

--- a/docs/DATA_CONTENT_ASSET_WORKFLOW.md
+++ b/docs/DATA_CONTENT_ASSET_WORKFLOW.md
@@ -175,10 +175,20 @@ Commands available today:
 ./freven_boot config explain --instance <instance> --experience <experience_id>
 ./freven_boot providers check --instance <instance> --experience <experience_id>
 ./freven_boot providers explain --instance <instance> --experience <experience_id>
+./freven_boot content-assets check --instance <instance> --experience <experience_id>
+./freven_boot content-assets explain --instance <instance> --experience <experience_id>
 ```
 
-The dedicated resolved content/assets check command is tracked separately by
-frevenengine/freven-devkit#92. Friendly asset diagnostic output is defined in
+Use `content-assets check` before launch when a texture, material, model, block
+visual, or content patch does not load. It resolves the selected experience or
+stack and validates the rc10 visual asset load plan without starting the full
+client/server runtime.
+
+Use `content-assets explain` when you need to inspect resolved content layers,
+effective assets, dependency edges, shadowed overrides, internal slots, and the
+load-plan fingerprint.
+
+Friendly asset diagnostic output is defined in
 [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md).
 
 ## Example: data-backed Wasm mod

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -92,3 +92,21 @@ Common examples:
 - Material Registry v1 bridge error during `providers check`: this is a
   current command limitation tracked by frevenengine/freven-devkit#85, not a
   reason to move visual content into config.
+
+## Texture, material, model, or content patch does not load
+
+Run the resolved content/assets check first:
+
+```bash
+./freven_boot content-assets check --instance <instance> --experience <experience_id>
+```
+
+To inspect the selected graph:
+
+```bash
+./freven_boot content-assets explain --instance <instance> --experience <experience_id>
+```
+
+Use this before launching the full client/server runtime. The command reports
+manifest/load-plan/texture asset failures with FVK diagnostics and distinguishes
+authored content/schema problems from runtime/provider bridge problems.


### PR DESCRIPTION
## Summary

Documents the new resolved content/assets validation command:

- `freven_boot content-assets check`
- `freven_boot content-assets explain`

Updates the data/content workflow, asset pipeline diagnostics, and
troubleshooting docs to point authors at the new pre-launch validation path.

## Why

The Boot-side implementation landed in frevenengine/freven-boot#86.

This closes the DevKit-facing issue by documenting how authors should use the
command when textures, materials, models, block visuals, shader/effect data, or
content patches do not load.

## Validation

- git --no-pager diff --check
- rg -n "content-assets check|content-assets explain|freven-boot#86|freven-devkit#92|tracked separately|does not implement the final command|Texture, material, model" docs

Closes #92.