### PR TITLE
Document asset inspector devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Include:
 - [Data/content asset workflow](docs/DATA_CONTENT_ASSET_WORKFLOW.md)
 - [Asset pipeline diagnostics](docs/ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset authoring templates](docs/ASSET_AUTHORING_TEMPLATES.md)
+- [Asset inspector / devtools](docs/ASSET_INSPECTOR_DEVTOOLS.md)
 - [Provider selection authoring](docs/PROVIDER_AUTHORING.md)
 - [Block mutation authoring](docs/BLOCK_MUTATION_AUTHORING.md)
 - [Troubleshooting](docs/TROUBLESHOOTING.md)

--- a/docs/ASSET_AUTHORING_TEMPLATES.md
+++ b/docs/ASSET_AUTHORING_TEMPLATES.md
@@ -52,6 +52,7 @@ Copy a template directory into an instance `experiences/` directory, then run:
 
     freven_boot content-assets check --instance <instance> --experience <template_id>
     freven_boot content-assets explain --instance <instance> --experience <template_id>
+    freven_boot content-assets inspect --instance <instance> --experience <template_id>
 
 Before shipping:
 

--- a/docs/ASSET_INSPECTOR_DEVTOOLS.md
+++ b/docs/ASSET_INSPECTOR_DEVTOOLS.md
@@ -1,0 +1,88 @@
+# Asset inspector / devtools
+
+DevKit ships a first asset inspector surface through:
+
+    freven_boot content-assets inspect
+
+This is the rc10 CLI inspector for resolved visual asset load plans. It is not
+the final in-game debug UI, but it establishes the stable inspection contract
+that later UI/devtools surfaces should reuse.
+
+## Commands
+
+Inspect all resolved assets:
+
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id>
+
+Inspect one asset kind:
+
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind material
+
+Inspect one stable asset key:
+
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind material --key example.assets:materials/stone
+
+Show renderer/runtime internal slots:
+
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind material --key example.assets:materials/stone --show-internal
+
+## What it shows
+
+The inspector prints author-facing resolved asset information:
+
+- selected experience/stack content layers;
+- load-plan fingerprint;
+- texture/material/model/effect/generated counts;
+- owner layer for each matching asset;
+- source path when available;
+- dependencies;
+- shadowed declarations;
+- render-layer summary;
+- missing key guidance;
+- internal slots only when `--show-internal` is explicitly used.
+
+## Stable identity vs debug internals
+
+Stable author-facing identity is the asset key:
+
+    namespace:path
+
+Internal slots are renderer/runtime debug output. They are useful for diagnostics,
+performance debugging, and future UI inspector panels, but they are not an author
+API and should not be referenced from content, config, mods, saves, or templates.
+
+## Relationship to other content/assets commands
+
+Use:
+
+- `content-assets check` when something fails to load;
+- `content-assets explain` when you need the full resolved load plan;
+- `content-assets inspect` when you want a focused view of one kind/key or a
+  devtools-friendly summary.
+
+## Current scope
+
+This is the DevKit CLI inspector v1.
+
+It covers:
+
+- listing resolved textures/materials/models/effects/generated assets;
+- inspecting a specific stable key;
+- showing dependencies and shadowed declarations;
+- summarizing render layers;
+- exposing internal slot ids as debug-only output.
+
+Future runtime/in-game devtools can build on the same contract for:
+
+- block-under-cursor resolved asset inspection;
+- live visual overlays;
+- atlas/texture-array visualization;
+- hot reload event display;
+- richer material/shader diagnostics panels.
+
+## Related docs
+
+- [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
+- [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
+- [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)
+- [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/ASSET_PIPELINE_DIAGNOSTICS.md
+++ b/docs/ASSET_PIPELINE_DIAGNOSTICS.md
@@ -420,8 +420,8 @@ specifically debugging provider declarations.
   `content-assets explain` command surface for resolved visual load plans.
 - frevenengine/freven-boot#87 fixes the `providers check` Material Registry
   v1 bridge path by passing the resolved registry into provider validation.
-- frevenengine/freven-devkit#88 should display the same diagnostic fields in
-  the inspector/devtools UI.
+- frevenengine/freven-boot#89 adds the current CLI asset inspector surface
+  through `freven_boot content-assets inspect`.
 - frevenengine/freven-devkit#91 should use the same diagnostic codes during
   asset/content hot reload.
 - frevenengine/freven-boot#88 adds packaged asset authoring templates that


### PR DESCRIPTION
## Summary

Documents the new rc10 asset inspector/devtools surface:

- `freven_boot content-assets inspect`
- `--kind texture|material|model|effect|generated`
- `--key <namespace:path>`
- `--show-internal`

Adds a DevKit guide explaining stable asset keys, debug-only internal slots,
render-layer/dependency/shadowed inspection, and how this relates to
`content-assets check` and `content-assets explain`.

## Why

The Boot-side inspector implementation landed in frevenengine/freven-boot#89.

This closes the DevKit-facing issue with a CLI inspector v1 that future in-game
devtools can build on.

## Validation

- git --no-pager diff --check
- rg -n "Asset inspector|ASSET_INSPECTOR_DEVTOOLS|content-assets inspect|freven-boot#89|freven-devkit#88|show-internal|internal slots|block-under-cursor" README.md docs

Closes #88.
