### PR TITLE
Document asset content hot reload workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Include:
 - [Asset pipeline diagnostics](docs/ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset authoring templates](docs/ASSET_AUTHORING_TEMPLATES.md)
 - [Asset inspector / devtools](docs/ASSET_INSPECTOR_DEVTOOLS.md)
+- [Asset/content hot reload](docs/ASSET_CONTENT_HOT_RELOAD.md)
 - [Provider selection authoring](docs/PROVIDER_AUTHORING.md)
 - [Block mutation authoring](docs/BLOCK_MUTATION_AUTHORING.md)
 - [Troubleshooting](docs/TROUBLESHOOTING.md)

--- a/docs/ASSET_AUTHORING_TEMPLATES.md
+++ b/docs/ASSET_AUTHORING_TEMPLATES.md
@@ -53,6 +53,7 @@ Copy a template directory into an instance `experiences/` directory, then run:
     freven_boot content-assets check --instance <instance> --experience <template_id>
     freven_boot content-assets explain --instance <instance> --experience <template_id>
     freven_boot content-assets inspect --instance <instance> --experience <template_id>
+    freven_boot content-assets watch --instance <instance> --experience <template_id> --once
 
 Before shipping:
 

--- a/docs/ASSET_CONTENT_HOT_RELOAD.md
+++ b/docs/ASSET_CONTENT_HOT_RELOAD.md
@@ -1,0 +1,95 @@
+# Asset/content hot reload
+
+DevKit ships a conservative rc10 hot-reload workflow through:
+
+    freven_boot content-assets watch
+
+This is a development-only edit/check loop for visual content. It watches the
+resolved content roots and manifests for the selected experience or stack,
+rebuilds the visual asset load plan after edits, reports changed files, prints
+reload fingerprints, and keeps running after broken reload attempts.
+
+It does not yet perform live GPU texture replacement, material-table swapping,
+chunk-mesh invalidation, or in-game block-under-cursor refresh. Running sessions
+may still require restart until runtime hot reload hooks are added.
+
+## Commands
+
+Watch continuously:
+
+    freven_boot content-assets watch --instance <instance> --experience <experience_id>
+
+Use a shorter poll interval:
+
+    freven_boot content-assets watch --instance <instance> --experience <experience_id> --interval-ms 250
+
+Run one watch pass and exit:
+
+    freven_boot content-assets watch --instance <instance> --experience <experience_id> --once
+
+## What it reports
+
+Each watch pass reports:
+
+- selected experience or stack;
+- development-only reload mode;
+- watched content/manifests/source files;
+- changed files;
+- content/assets validation status;
+- visual load-plan fingerprint;
+- whether the fingerprint changed;
+- reload errors without crashing the watcher;
+- whether restart or future runtime hooks may still be required.
+
+## Safe reload contract
+
+Current rc10 behavior is conservative:
+
+- texture/material/model/content edits are revalidated without restarting the
+  watch process;
+- broken reload attempts print the same FVK diagnostic vocabulary used by
+  `content-assets check`;
+- the watcher remains active for the next edit;
+- production and release paths remain deterministic and do not depend on hot
+  reload state;
+- runtime live swap is explicitly not treated as available until engine/runtime
+  hooks own GPU/resource/chunk invalidation.
+
+## Recommended workflow
+
+1. Start from an asset authoring template.
+2. Run `content-assets check` once.
+3. Run `content-assets inspect` for the key you are editing.
+4. Start `content-assets watch`.
+5. Edit textures/materials/model or visual source files.
+6. Use the watch output to see changed files, diagnostics, and fingerprints.
+7. Restart a running client/server when the watcher says runtime live swap is not
+   attached.
+
+## Relationship to other commands
+
+Use:
+
+- `content-assets check` for pre-launch validation;
+- `content-assets explain` for the full resolved load plan;
+- `content-assets inspect` for a focused key/kind view;
+- `content-assets watch` for an edit/check loop while authoring visual content.
+
+## Future runtime hooks
+
+Future engine/runtime hot reload can build on this workflow for:
+
+- live texture upload replacement;
+- material table rebuilds;
+- model/block visual reload;
+- affected chunk mesh invalidation;
+- inspector hot reload event display;
+- in-game overlays showing which assets changed.
+
+## Related docs
+
+- [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
+- [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
+- [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)
+- [Asset inspector / devtools](ASSET_INSPECTOR_DEVTOOLS.md)
+- [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/ASSET_INSPECTOR_DEVTOOLS.md
+++ b/docs/ASSET_INSPECTOR_DEVTOOLS.md
@@ -77,7 +77,7 @@ Future runtime/in-game devtools can build on the same contract for:
 - block-under-cursor resolved asset inspection;
 - live visual overlays;
 - atlas/texture-array visualization;
-- hot reload event display;
+- hot reload event display, starting with `content-assets watch` output;
 - richer material/shader diagnostics panels.
 
 ## Related docs
@@ -85,4 +85,5 @@ Future runtime/in-game devtools can build on the same contract for:
 - [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
 - [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)
+- [Asset/content hot reload](ASSET_CONTENT_HOT_RELOAD.md)
 - [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/ASSET_PIPELINE_DIAGNOSTICS.md
+++ b/docs/ASSET_PIPELINE_DIAGNOSTICS.md
@@ -422,8 +422,9 @@ specifically debugging provider declarations.
   v1 bridge path by passing the resolved registry into provider validation.
 - frevenengine/freven-boot#89 adds the current CLI asset inspector surface
   through `freven_boot content-assets inspect`.
-- frevenengine/freven-devkit#91 should use the same diagnostic codes during
-  asset/content hot reload.
+- frevenengine/freven-boot#90 adds the current conservative
+  `freven_boot content-assets watch` workflow for asset/content hot reload
+  iteration.
 - frevenengine/freven-boot#88 adds packaged asset authoring templates that
   avoid these diagnostics by default.
 

--- a/docs/DATA_CONTENT_ASSET_WORKFLOW.md
+++ b/docs/DATA_CONTENT_ASSET_WORKFLOW.md
@@ -177,6 +177,8 @@ Commands available today:
 ./freven_boot providers explain --instance <instance> --experience <experience_id>
 ./freven_boot content-assets check --instance <instance> --experience <experience_id>
 ./freven_boot content-assets explain --instance <instance> --experience <experience_id>
+./freven_boot content-assets inspect --instance <instance> --experience <experience_id>
+./freven_boot content-assets watch --instance <instance> --experience <experience_id>
 ```
 
 Use `content-assets check` before launch when a texture, material, model, block
@@ -187,6 +189,11 @@ client/server runtime.
 Use `content-assets explain` when you need to inspect resolved content layers,
 effective assets, dependency edges, shadowed overrides, internal slots, and the
 load-plan fingerprint.
+
+Use `content-assets watch` during development when you want a conservative
+edit/check loop for texture, material, model, visual, or content source changes.
+The watcher validates changes and reports diagnostics/fingerprints, but runtime
+live swap may still require restart until engine hot reload hooks are attached.
 
 Friendly asset diagnostic output is defined in
 [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md).


### PR DESCRIPTION
## Summary

Documents the rc10 asset/content hot reload workflow:

- `freven_boot content-assets watch`
- `--interval-ms <ms>`
- `--once`

Adds a DevKit guide explaining the conservative development-only reload
contract: changed files, visual load-plan fingerprints, diagnostics that do not
crash the watcher, and clear restart/runtime-hook guidance.

## Why

The Boot-side watch implementation landed in frevenengine/freven-boot#90.

This closes the DevKit-facing hot reload workflow issue without pretending that
runtime GPU/material-table/chunk-mesh live swap is already implemented.

## Validation

- git --no-pager diff --check
- rg -n "Asset/content hot reload|ASSET_CONTENT_HOT_RELOAD|content-assets watch|freven-boot#90|freven-devkit#91|runtime live swap|development-only|restart required|hot reload" README.md docs

Closes #91.
