### PR TITLE
Document engine and Vanilla ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Include:
 - [Mod DevTools v1](docs/MOD_DEVTOOLS.md)
 - [Friendly authoring diagnostics](docs/FRIENDLY_DIAGNOSTICS.md)
 - [Project templates](docs/PROJECT_TEMPLATES.md)
+- [Engine vs Vanilla ownership](docs/ENGINE_VANILLA_OWNERSHIP.md)
 - [Provider selection authoring](docs/PROVIDER_AUTHORING.md)
 - [Block mutation authoring](docs/BLOCK_MUTATION_AUTHORING.md)
 - [Troubleshooting](docs/TROUBLESHOOTING.md)

--- a/docs/ASSET_AUTHORING_TEMPLATES.md
+++ b/docs/ASSET_AUTHORING_TEMPLATES.md
@@ -80,4 +80,6 @@ not load.
 
 ## Related docs
 
+- [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
+
 - [Project templates](PROJECT_TEMPLATES.md)

--- a/docs/ASSET_CONTENT_HOT_RELOAD.md
+++ b/docs/ASSET_CONTENT_HOT_RELOAD.md
@@ -88,6 +88,8 @@ Future engine/runtime hot reload can build on this workflow for:
 
 ## Related docs
 
+- [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
+
 - [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
 - [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)

--- a/docs/ASSET_INSPECTOR_DEVTOOLS.md
+++ b/docs/ASSET_INSPECTOR_DEVTOOLS.md
@@ -82,6 +82,8 @@ Future runtime/in-game devtools can build on the same contract for:
 
 ## Related docs
 
+- [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
+
 - [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
 - [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)

--- a/docs/ASSET_PIPELINE_DIAGNOSTICS.md
+++ b/docs/ASSET_PIPELINE_DIAGNOSTICS.md
@@ -428,6 +428,13 @@ specifically debugging provider declarations.
 - frevenengine/freven-boot#88 adds packaged asset authoring templates that
   avoid these diagnostics by default.
 
+## Engine vs Vanilla ownership
+
+Asset diagnostics must not tell authors to fix Vanilla style in engine code or to
+copy renderer internals into content. Use [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
+when deciding whether the fix belongs to Engine, SDK, Vanilla, a standalone
+product, a mod, a content pack, generated cache, or save/world state.
+
 ## Done criteria for this diagnostic layer
 
 This diagnostic layer is present when DevKit users and future tooling agree on:

--- a/docs/DATA_CONTENT_ASSET_WORKFLOW.md
+++ b/docs/DATA_CONTENT_ASSET_WORKFLOW.md
@@ -198,6 +198,12 @@ live swap may still require restart until engine hot reload hooks are attached.
 Friendly asset diagnostic output is defined in
 [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md).
 
+For shader/material/visual-style ownership, use
+[Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md). The short rule is:
+Engine resolves and renders, SDK defines stable contracts, Vanilla owns
+first-party style, standalone products may replace Vanilla, and mods/content
+packs override through declared selected layers.
+
 ## Example: data-backed Wasm mod
 
 A server-side Wasm mod can provide behavior while authored content remains data:

--- a/docs/ENGINE_VANILLA_OWNERSHIP.md
+++ b/docs/ENGINE_VANILLA_OWNERSHIP.md
@@ -1,0 +1,230 @@
+# Engine vs Vanilla ownership
+
+Freven DevKit rc10 keeps the engine, SDK, Vanilla, standalone products, mods,
+and content packs separated by ownership boundary.
+
+This matters most for shaders, materials, textures, block visuals, models,
+visual style, fallback assets, and generated renderer/cache output.
+
+## Rule of thumb
+
+- Engine owns generic rendering/runtime capability.
+- SDK owns stable author-facing contracts and keys.
+- Vanilla owns first-party gameplay/content/style.
+- Standalone products may replace Vanilla completely.
+- Mods and content packs add or override through declared dependencies, selected
+  experience layers, and content/asset manifests.
+
+Do not move Vanilla style into engine code just because Vanilla is currently the
+bundled reference experience.
+
+Do not move renderer internals into authored content just because they are useful
+for debugging.
+
+## Ownership map
+
+| Layer | Owns | Must not own |
+| --- | --- | --- |
+| Engine/runtime | renderer implementation, asset loading, material registry resolution, fallback rendering, generated renderer/cache output, diagnostics plumbing | Vanilla block library, Vanilla visual style, mod-authored schemas, stable author namespaces |
+| SDK | public schemas, stable `namespace:path` keys, guest APIs, material/model/visual/effect contract vocabulary | renderer slots, Bevy/wgpu handles, Vanilla content, product-specific style |
+| DevKit / Boot | validation commands, inspectors, templates, packaging, author-facing diagnostics, resolved load-plan explanation | first-party content policy, renderer implementation, hidden gameplay defaults |
+| Vanilla | first-party blocks, tags, materials, textures, visual style, default providers, reference gameplay integration | engine/platform behavior, mandatory base for all games, SDK schemas |
+| Standalone product | product identity, bundled default experience, product-owned content/style/providers/config | implicit dependency on Vanilla, reuse of shipped proof experience as authoring contract |
+| Mod | runtime behavior, providers, config schema, package identity, declared content/assets | unrestricted engine access, silent ownership of another namespace |
+| Content pack | data/assets only: textures, materials, models, visuals, tags, recipes, patches where allowed | executable behavior, renderer handles, runtime ids, hidden side effects |
+| Generated cache | rebuildable atlas/load-plan/material-table/shader-cache output | authored source of truth |
+| Save/world state | persisted runtime world/session/player state | shipped content defaults, generated cache, package manifests |
+
+## Visual asset rule
+
+Author-facing visual identity is always a stable key:
+
+    namespace:path
+
+Examples:
+
+    freven.vanilla:textures/stone
+    freven.vanilla:block/stone
+    example.pack:materials/block/polished_stone
+    example.total:effects/tonemap_default
+
+Renderer/backend identity is never authored source:
+
+- renderer material slot;
+- atlas coordinate;
+- texture-array layer;
+- GPU handle;
+- Bevy entity/component handle;
+- shader module handle;
+- pipeline id;
+- generated cache path.
+
+Inspectors may show these values only as debug/devtools output.
+
+## Engine-owned
+
+Engine/runtime may provide:
+
+- renderer backends;
+- asset file loading;
+- texture/material/model/effect resolution;
+- Material Registry v1 bridge;
+- fallback/debug rendering when authored assets are missing or unsupported;
+- generated load plans, atlases, texture arrays, material tables, and shader
+  caches;
+- runtime invalidation hooks for future live reload;
+- low-level diagnostics that DevKit turns into author-facing messages.
+
+Engine/runtime must stay generic. It should not hardcode that stone, grass,
+humanoid controls, Vanilla lighting, Vanilla foliage motion, or Vanilla material
+names are special engine concepts.
+
+## SDK-owned
+
+SDK owns the stable vocabulary that authors and guests can rely on:
+
+- schema versions;
+- `namespace:path` key shape;
+- material/model/visual/effect contract fields;
+- guest API helpers;
+- capability and fallback vocabulary;
+- validation model vocabulary.
+
+SDK must not expose renderer-local ids as normal authoring API. If a debug or
+legacy helper still accepts a low-level value, docs must label it as transitional
+or debug-only.
+
+## Vanilla-owned
+
+Vanilla owns first-party Freven gameplay/content/style:
+
+- `freven.vanilla:*` blocks and providers;
+- default first-party textures and materials;
+- first-party block tags;
+- first-party movement/controller/control defaults;
+- reference integration patterns;
+- Vanilla-specific visual style choices.
+
+Vanilla is allowed to be bundled by a Vanilla product/profile. It is not a
+required dependency of the engine, SDK, or standalone products.
+
+## Standalone-owned
+
+A standalone product may ship a zero-Vanilla experience.
+
+It should own:
+
+- product id/name;
+- default bundled experience;
+- product-owned content/assets;
+- product-owned provider defaults;
+- product-owned visual style;
+- product packaging and launch profile.
+
+A standalone game should not copy `freven.vanilla` just to get a starting visual
+style. Use project templates, asset authoring templates, and the standalone
+product generator instead.
+
+## Mods and content packs
+
+Mods and content packs may extend or override selected content through declared
+dependencies, selected stack layers, and content/assets manifests.
+
+Valid examples:
+
+- a Vanilla texture pack replacing `freven.vanilla:textures/grass` through an
+  allowed selected layer;
+- a material pack adding `example.pack:materials/block/marble`;
+- a block mod registering gameplay block keys and pairing them with authored
+  material keys;
+- a total conversion replacing the selected base experience instead of depending
+  on Vanilla.
+
+Invalid examples:
+
+- writing renderer slots into content files;
+- depending on atlas coordinates as public API;
+- putting Vanilla material libraries in engine code;
+- using generated cache as authored source;
+- silently taking ownership of another namespace without declared override policy.
+
+## Shaders and effects
+
+Shader/effect ownership follows the same split:
+
+- Engine owns shader loading, compilation, backend resources, fallback shader
+  behavior, and generated shader cache.
+- SDK owns the effect contract vocabulary, capability names, and stable effect
+  keys.
+- Vanilla owns Vanilla-specific effect choices and style presets.
+- Standalone products may choose a different style/effect library.
+- Mods/content packs may request semantic effects inside allowed policy.
+
+Raw shader source or renderer plugins are not normal content by default. They
+require explicit future trust/product policy.
+
+## Fallback assets
+
+Fallbacks are engine/runtime behavior, not Vanilla content.
+
+A missing material may fall back to a debug tint so authors can see the problem,
+but that fallback does not mean the engine owns the final material. The owning
+content layer must still declare the texture/material/model/effect source.
+
+## Debug output
+
+DevKit tools may show internal slots for diagnostics:
+
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id> --show-internal
+
+Internal slots are not stable author-facing identity. Do not copy them into
+authored content.
+
+## Diagnostic flow
+
+When a visual/content problem appears, use focused commands:
+
+    freven_boot content-assets check --instance <instance> --experience <experience_id>
+    freven_boot content-assets explain --instance <instance> --experience <experience_id>
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id>
+    freven_boot content-assets watch --instance <instance> --experience <experience_id> --once
+
+If provider defaults or worldgen selection are involved:
+
+    freven_boot providers list --instance <instance> --experience <experience_id>
+    freven_boot providers explain --instance <instance> --experience <experience_id>
+
+Fix the owning source:
+
+- `mod.toml` for package identity/capability/schema references;
+- `experience.toml` or `experience.stack.toml` for selected mods/defaults/content
+  roots;
+- `content.manifest` and `content/` for authored content/visual declarations;
+- asset files for images/models/shaders/sounds/fonts;
+- generated cache only by rebuilding it;
+- world/save state only through migration/runtime tools.
+
+## Long-term contract
+
+New visual/data features should pass these checks:
+
+- Can a zero-Vanilla standalone game use this without Vanilla?
+- Can Vanilla express its style through authored content instead of engine code?
+- Can a mod/content pack add or override through declared layers?
+- Are stable keys used instead of renderer ids?
+- Are generated caches rebuildable and not source?
+- Do diagnostics point to the owning file/field?
+
+If any answer is no, the feature is probably crossing an ownership boundary.
+
+## Related docs
+
+- [Getting started](GETTING_STARTED.md)
+- [Project templates](PROJECT_TEMPLATES.md)
+- [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
+- [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)
+- [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
+- [Asset inspector / devtools](ASSET_INSPECTOR_DEVTOOLS.md)
+- [Asset/content hot reload](ASSET_CONTENT_HOT_RELOAD.md)
+- [Friendly authoring diagnostics](FRIENDLY_DIAGNOSTICS.md)
+- [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/FRIENDLY_DIAGNOSTICS.md
+++ b/docs/FRIENDLY_DIAGNOSTICS.md
@@ -165,6 +165,8 @@ Use diagnostics to fix the owning source:
 
 ## Related docs
 
+- [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
+
 - [Getting started](GETTING_STARTED.md)
 - [First Wasm mod](FIRST_WASM_MOD.md)
 - [Provider selection authoring](PROVIDER_AUTHORING.md)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -104,6 +104,11 @@ simulation mods.
 See [Project templates](PROJECT_TEMPLATES.md) before creating a new mod/project
 layout by hand.
 
+Use [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md) when deciding
+whether a shader, material, visual style, texture library, provider default, or
+content pack belongs in Engine, SDK, Vanilla, a standalone product, or a selected
+mod/content layer.
+
 
 Current authoring ownership:
 

--- a/docs/MOD_DEVTOOLS.md
+++ b/docs/MOD_DEVTOOLS.md
@@ -157,6 +157,8 @@ authoring contracts:
 
 ## Related docs
 
+- [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
+
 - [Getting started](GETTING_STARTED.md)
 - [Provider selection authoring](PROVIDER_AUTHORING.md)
 - [Block mutation authoring](BLOCK_MUTATION_AUTHORING.md)

--- a/docs/PROJECT_TEMPLATES.md
+++ b/docs/PROJECT_TEMPLATES.md
@@ -45,6 +45,16 @@ Validate the template catalog from Boot source:
 
 Project templates keep source ownership explicit:
 
+- engine/runtime behavior stays generic;
+- Vanilla is a reference/base experience, not a required dependency;
+- standalone products may be zero-Vanilla and product-owned;
+- mods/content packs extend selected bases through declared layers;
+- visual style belongs to Vanilla, a standalone product, or selected content packs,
+  not engine code.
+
+See [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md) for the full
+shader/material/visual-style boundary.
+
 - `mod.toml` is package identity, runtime type, trust/surface/capability metadata;
 - `experience.toml` and `experience.stack.toml` select mods, defaults, content roots, and stack overlays;
 - `config.schema.toml` defines tunable runtime settings;

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -134,3 +134,7 @@ Start with:
     freven_boot config check --instance <instance> --experience <experience_id>
     freven_boot providers explain --instance <instance> --experience <experience_id>
     freven_boot content-assets check --instance <instance> --experience <experience_id>
+
+## Related docs
+
+- [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)


### PR DESCRIPTION
## Summary

Documents the Engine vs Vanilla ownership boundary for shaders, materials,
textures, visual style, fallback assets, standalone products, mods, and content
packs.

Adds a canonical DevKit ownership guide and links it from the current rc10
authoring workflow docs:

- getting started
- project templates
- data/content asset workflow
- asset authoring templates
- asset pipeline diagnostics
- asset inspector/devtools
- asset/content hot reload
- friendly diagnostics
- troubleshooting

## Why

Freven needs a clear long-term boundary:

- Engine owns generic renderer/runtime capability, asset loading, fallback
  rendering, generated caches, and diagnostics plumbing.
- SDK owns stable author-facing schemas and namespace:path keys.
- Vanilla owns first-party gameplay/content/materials/textures/visual style.
- Standalone products may be zero-Vanilla and product-owned.
- Mods/content packs add or override through declared selected layers.

This prevents future visual work from accidentally hardcoding Vanilla style into
engine code or exposing renderer internals as authored content.

## Validation

- git --no-pager diff --check
- rg -n "Engine vs Vanilla ownership|ENGINE_VANILLA_OWNERSHIP|Engine owns|SDK owns|Vanilla owns|Standalone products may|zero-Vanilla|renderer internals|visual style|fallback assets|freven-boot#92|content-assets inspect" README.md docs

Closes #89.
