### PR TITLE
Document content family authoring workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Include:
 - [Data/content asset workflow](docs/DATA_CONTENT_ASSET_WORKFLOW.md)
 - [Asset pipeline diagnostics](docs/ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset authoring templates](docs/ASSET_AUTHORING_TEMPLATES.md)
+- [Content family authoring](docs/CONTENT_FAMILY_AUTHORING.md)
 - [Asset inspector / devtools](docs/ASSET_INSPECTOR_DEVTOOLS.md)
 - [Asset/content hot reload](docs/ASSET_CONTENT_HOT_RELOAD.md)
 - [Mod DevTools v1](docs/MOD_DEVTOOLS.md)

--- a/docs/ASSET_AUTHORING_TEMPLATES.md
+++ b/docs/ASSET_AUTHORING_TEMPLATES.md
@@ -16,6 +16,9 @@ content-first starting points for visual/content authoring.
 | `material_pack` | You want reusable material keys shared by blocks/models. |
 | `block_model_pack` | You want forward-compatible model/visual source files next to validated materials. |
 | `standalone_visual_style_pack` | A standalone product owns its style instead of inheriting Vanilla visuals. |
+| `rock_family_pack` | You want compact generated rock variants with material/visual/tag entries. |
+| `soil_grass_family_pack` | You want generated soil x grass coverage variants with skipped combinations. |
+| `colored_glass_family_pack` | You want generated transparent colored-glass variants. |
 
 ## What each template contains
 
@@ -26,7 +29,8 @@ Each template includes:
 - `content/textures/example_16.png`;
 - `content/textures/example_32.png`;
 - material declarations;
-- README notes with `content-assets check` and `content-assets explain`.
+- family declarations for generated variant templates where applicable;
+- README notes with `content-assets check`, `content-assets explain`, and `content-assets inspect --kind generated`.
 
 `block_model_pack` also includes forward-compatible model and block-visual
 source skeleton files. They are tracked through `content.manifest` entries while
@@ -83,3 +87,25 @@ not load.
 - [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
 
 - [Project templates](PROJECT_TEMPLATES.md)
+
+## Family templates
+
+Family templates demonstrate compact generated variant authoring:
+
+    freven_boot content-assets check --instance <instance> --experience <template_id>
+    freven_boot content-assets inspect --instance <instance> --experience <template_id> --kind generated
+
+Use:
+
+- `rock_family_pack` for rock variants;
+- `soil_grass_family_pack` for cartesian-product variants with skipped
+  combinations;
+- `colored_glass_family_pack` for transparent generated variants with structured
+  axis metadata.
+
+The framed-glass workflow is currently an advanced composition of
+`block_model_pack` and `colored_glass_family_pack`; a dedicated framed-glass
+family template should wait until rich per-part model-family templates are
+stable.
+
+See [Content family authoring](CONTENT_FAMILY_AUTHORING.md).

--- a/docs/ASSET_INSPECTOR_DEVTOOLS.md
+++ b/docs/ASSET_INSPECTOR_DEVTOOLS.md
@@ -22,6 +22,14 @@ Inspect one stable asset key:
 
     freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind material --key example.assets:materials/stone
 
+Inspect generated content family output:
+
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind generated
+
+Inspect one content family:
+
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind generated --key example.assets:families/rock
+
 Show renderer/runtime internal slots:
 
     freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind material --key example.assets:materials/stone --show-internal
@@ -39,6 +47,7 @@ The inspector prints author-facing resolved asset information:
 - shadowed declarations;
 - render-layer summary;
 - missing key guidance;
+- generated content family output when `--kind generated` is selected;
 - internal slots only when `--show-internal` is explicitly used.
 
 ## Stable identity vs debug internals
@@ -90,3 +99,17 @@ Future runtime/in-game devtools can build on the same contract for:
 - [Asset/content hot reload](ASSET_CONTENT_HOT_RELOAD.md)
 - [Mod DevTools v1](MOD_DEVTOOLS.md)
 - [Troubleshooting](TROUBLESHOOTING.md)
+
+## Content family inspection
+
+For family-authored content, use:
+
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind generated
+
+The inspector lists family keys, axes, allow/skip rule counts, generated
+materials, generated models, generated visuals, and generated tags.
+
+This is a source/devtools view of load/build-stage generated semantic content.
+It is not a renderer slot browser.
+
+See [Content family authoring](CONTENT_FAMILY_AUTHORING.md).

--- a/docs/ASSET_PIPELINE_DIAGNOSTICS.md
+++ b/docs/ASSET_PIPELINE_DIAGNOSTICS.md
@@ -445,3 +445,34 @@ This diagnostic layer is present when DevKit users and future tooling agree on:
 - the boundary that owns each kind of fix;
 - examples for common texture/material/model failures;
 - relationship to content/assets check, inspector, hot reload, and packaging.
+
+## Content family diagnostics
+
+Content family diagnostics are content diagnostics. They should point to
+`content.manifest`, the family key, and relevant axis values.
+
+Example:
+
+    error FVK-CONTENT-MANIFEST
+    invalid content manifest family 'example.family:families/broken':
+    combination 'color=red' is both allowed and skipped: intentional conflict
+
+A useful family diagnostic should include:
+
+- family key;
+- source manifest path;
+- source template or field when known;
+- axis values involved in the failure;
+- generated key when the failure concerns generated output;
+- one concrete fix or next command.
+
+Suggested next commands:
+
+    freven_boot content-assets check --instance <instance> --experience <experience_id>
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind generated
+
+Diagnostics must remain author-facing. Runtime ids, renderer slots, atlas
+coordinates, and GPU handles may only appear in explicit debug/internal sections,
+not as required fixes.
+
+See [Content family authoring](CONTENT_FAMILY_AUTHORING.md).

--- a/docs/CONTENT_FAMILY_AUTHORING.md
+++ b/docs/CONTENT_FAMILY_AUTHORING.md
@@ -1,0 +1,178 @@
+# Content family authoring
+
+Content families are compact authoring declarations for generated content
+variants.
+
+Use them when many content entries share the same shape but differ by one or
+more variant axes, such as rock type, soil type, grass coverage, or glass color.
+
+Current DevKit support is backed by:
+
+- freven-engine content family expansion;
+- freven-boot `content-assets check`;
+- freven-boot `content-assets inspect --kind generated`;
+- asset authoring templates shipped under `templates/asset_authoring_templates/`.
+
+## Core rule
+
+A family is source. Generated entries are derived semantic content.
+
+Flow:
+
+    authored content.manifest
+      [[families]]
+        axes / allow / skip / templates
+            |
+            v
+    load/build-stage family expansion
+            |
+            v
+    ordinary semantic entries
+      materials / models / block visuals / block tags
+            |
+            v
+    runtime consumers
+      material registry / visual load plan / block visual mesh table / tag registry
+
+Do not author or depend on renderer/runtime internals in family source:
+
+- no runtime block ids;
+- no renderer slots;
+- no atlas coordinates;
+- no GPU handles;
+- no generated cache paths as source truth.
+
+Use stable `namespace:path` keys.
+
+## Expansion order
+
+The author-facing order is:
+
+1. resolve the selected experience or stack;
+2. collect effective content layers;
+3. load each `content.manifest`;
+4. validate authored declarations, including `[[families]]`;
+5. expand families into normal semantic entries;
+6. validate generated references after expansion;
+7. apply the existing layer/override/load-plan rules used by runtime consumers.
+
+Family expansion is not renderer-time logic and not Vanilla-specific hardcoding.
+
+Patch/merge semantics still operate on stable semantic content keys. A generated
+entry should be treated like any other material/model/visual/tag once expansion
+has completed. If a selected layer wants to override generated output, it should
+override the stable generated key intentionally rather than referring to runtime
+internals.
+
+## Starter templates
+
+DevKit packages include family-focused asset templates:
+
+| Template | Purpose |
+| --- | --- |
+| `rock_family_pack` | Generates rock materials, block visuals, and a rock tag from a `rock` axis. |
+| `soil_grass_family_pack` | Generates soil x grass-coverage variants and demonstrates skipped combinations. |
+| `colored_glass_family_pack` | Generates transparent colored-glass materials and visuals from structured color metadata. |
+
+Copy one into an instance:
+
+    cp -R templates/asset_authoring_templates/rock_family_pack \
+      instances/dev/experiences/example.asset.rock_family_pack
+
+Then validate it:
+
+    freven_boot content-assets check \
+      --instance instances/dev \
+      --experience example.asset.rock_family_pack
+
+Inspect generated output:
+
+    freven_boot content-assets inspect \
+      --instance instances/dev \
+      --experience example.asset.rock_family_pack \
+      --kind generated
+
+Inspect one family:
+
+    freven_boot content-assets inspect \
+      --instance instances/dev \
+      --experience example.asset.rock_family_pack \
+      --kind generated \
+      --key example.asset.rock_family_pack:families/rock
+
+## What `check` catches
+
+`content-assets check` validates both authored source and generated output.
+
+It should catch:
+
+- invalid family keys;
+- invalid axis names or values;
+- unknown allow/skip axis references;
+- contradictory allow/skip combinations;
+- generated key conflicts;
+- missing generated texture/material/model/visual dependencies;
+- bad render-layer or tint metadata after expansion.
+
+Family diagnostics should include the family key and, where relevant, axis
+values such as `color=red` or `grass=covered, soil=sand`.
+
+## What `inspect --kind generated` shows
+
+The generated inspector is author-facing. It lists:
+
+- authored family key;
+- owning content layer;
+- source manifest path;
+- axes and values;
+- allow/skip rule counts;
+- generated material keys;
+- generated model keys;
+- generated block visual keys;
+- generated block tag keys.
+
+It intentionally does not expose renderer slots, runtime ids, atlas positions,
+or GPU handles as authoring API.
+
+## Skipped and allowed combinations
+
+Use `[[families.skip]]` to omit invalid combinations.
+
+Example:
+
+    [[families.skip]]
+    grass = "covered"
+    soil = "sand"
+    reason = "covered sand intentionally omitted"
+
+Use `[[families.allow]]` when the authored family should include only a small
+subset of the cartesian product.
+
+If a combination is both allowed and skipped, `content-assets check` should fail
+with the family key, axis values, and skip reason.
+
+## Framed glass and advanced model families
+
+Current rc10 family templates focus on entries that are already represented in
+the stable manifest path: materials, models, block visuals, and block tags.
+
+For framed-glass-style authoring today:
+
+- start from `block_model_pack` for model/visual structure;
+- use `colored_glass_family_pack` for transparent color-family material/visual
+  generation;
+- keep custom model source files as authored content until richer per-part model
+  family templates are stabilized.
+
+A dedicated framed-glass family template should be added only when model-family
+templates can express the required per-part/cuboid structure without hiding
+renderer or mesh internals in author source.
+
+## Related docs
+
+- [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
+- [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)
+- [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
+- [Asset inspector / devtools](ASSET_INSPECTOR_DEVTOOLS.md)
+- [Mod DevTools v1](MOD_DEVTOOLS.md)
+- [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/DATA_CONTENT_ASSET_WORKFLOW.md
+++ b/docs/DATA_CONTENT_ASSET_WORKFLOW.md
@@ -186,6 +186,9 @@ visual, or content patch does not load. It resolves the selected experience or
 stack and validates the rc10 visual asset load plan without starting the full
 client/server runtime.
 
+Use `content-assets inspect --kind generated` when you need to inspect content
+family expansion output before launch.
+
 Use `content-assets explain` when you need to inspect resolved content layers,
 effective assets, dependency edges, shadowed overrides, internal slots, and the
 load-plan fingerprint.
@@ -343,3 +346,26 @@ This workflow layer is considered present when DevKit users can answer:
 - what should never be edited as source?
 - which current commands can I run before launch?
 - which follow-up commands will provide deeper resolved content/asset checks?
+
+## Content family expansion
+
+Content families are compact source declarations in `content.manifest`. They
+expand during the load/build stage into ordinary semantic entries before runtime
+consumers build material registries, visual load plans, block visual mesh tables,
+or tag registries.
+
+Expansion order:
+
+1. resolve selected experience/stack layers;
+2. load authored content manifests;
+3. validate family declarations;
+4. expand axes, allowed combinations, skipped combinations, and templates;
+5. validate generated materials/models/visuals/tags;
+6. consume the expanded semantic entries through the normal content/assets
+   pipeline.
+
+Generated family output participates in the same stable-key override and
+patch/merge rules as hand-authored content. Authors should override generated
+semantic keys intentionally, not renderer/runtime internals.
+
+See [Content family authoring](CONTENT_FAMILY_AUTHORING.md).

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -116,6 +116,9 @@ Current authoring ownership:
   shipping authored gameplay definitions, visual content declarations,
   data-only content, or product-owned content; do not put authored content
   data in active config, generated cache, or save/world state
+* use [`CONTENT_FAMILY_AUTHORING.md`](CONTENT_FAMILY_AUTHORING.md) when
+  generating rock, soil/grass, colored-glass, or similar variant families from
+  compact content source
 * use `freven_guest_sdk` / `freven_mod_api` only for neutral platform-shaped
   declarations
 * use `freven_world_guest_sdk` / `freven_world_api` for gameplay, block/content

--- a/docs/MOD_DEVTOOLS.md
+++ b/docs/MOD_DEVTOOLS.md
@@ -20,6 +20,7 @@ editing for every subsystem.
 | Check texture/material/model/content graph | `freven_boot content-assets check` |
 | Print full resolved content/assets load plan | `freven_boot content-assets explain` |
 | Inspect one asset kind/key | `freven_boot content-assets inspect` |
+| Inspect generated content family entries | `freven_boot content-assets inspect --kind generated` |
 | Watch content/assets during visual iteration | `freven_boot content-assets watch` |
 | Inspect runtime/debug metrics in client | Debug HUD |
 | Export/debug HUD metrics for CI/log review | Debug HUD dump/log consumers |
@@ -55,6 +56,10 @@ Use:
     freven_boot content-assets inspect --instance <instance> --experience <experience_id>
     freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind material
     freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind material --key example.assets:materials/stone
+
+For content families, inspect generated entries with:
+
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind generated
 
 Stable author-facing identity is always a `namespace:path` key.
 
@@ -169,3 +174,4 @@ authoring contracts:
 - [Asset/content hot reload](ASSET_CONTENT_HOT_RELOAD.md)
 - [Friendly authoring diagnostics](FRIENDLY_DIAGNOSTICS.md)
 - [Troubleshooting](TROUBLESHOOTING.md)
+- [Content family authoring](CONTENT_FAMILY_AUTHORING.md)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -138,3 +138,25 @@ Start with:
 ## Related docs
 
 - [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
+
+## Content family expansion fails
+
+Run:
+
+    ./freven_boot content-assets check --instance <instance> --experience <experience_id>
+
+Then inspect generated output after the manifest validates:
+
+    ./freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind generated
+
+Check:
+
+- the family key is namespaced;
+- every axis has valid values;
+- `allow` and `skip` rules reference existing axes and values;
+- no combination is both allowed and skipped;
+- generated material/model/visual/tag keys do not conflict unintentionally;
+- generated materials reference existing textures;
+- generated visuals reference existing models and materials.
+
+See [Content family authoring](CONTENT_FAMILY_AUTHORING.md).


### PR DESCRIPTION
## Summary

Documents the DevKit content family authoring workflow.

This adds:

- docs/CONTENT_FAMILY_AUTHORING.md
- family expansion order and relationship to patch/merge semantics
- content-assets check guidance for family diagnostics
- content-assets inspect --kind generated guidance for generated entries
- family template guidance for:
  - rock_family_pack
  - soil_grass_family_pack
  - colored_glass_family_pack
- honest v1 boundary for framed-glass/model-family templates
- links from existing DevKit authoring, diagnostics, inspector, devtools, getting-started, and troubleshooting docs

## Why

freven-engine#306 implemented deterministic content family expansion.
freven-boot#97 exposed check/inspect support and starter templates.

DevKit docs now need one stable author-facing path so creators can validate and inspect generated family output before launch without treating renderer/runtime internals as authored content.

Closes #106.

## Validation

- rg -n 'CONTENT_FAMILY_AUTHORING|Content family authoring|content-assets inspect --instance <instance> --experience <experience_id> --kind generated|rock_family_pack|soil_grass_family_pack|colored_glass_family_pack|framed-glass|patch/merge|runtime ids|renderer slots' README.md docs
- test -f docs/CONTENT_FAMILY_AUTHORING.md
- git --no-pager diff --check

Depends on frevenengine/freven-engine#306.
Related to frevenengine/freven-boot#97.
