### PR TITLE
Document modular content authoring workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Include:
 - [Getting started](docs/GETTING_STARTED.md)
 - [First Wasm mod](docs/FIRST_WASM_MOD.md)
 - [Data/content asset workflow](docs/DATA_CONTENT_ASSET_WORKFLOW.md)
+- [Modular content authoring](docs/MODULAR_CONTENT_AUTHORING.md)
 - [Asset pipeline diagnostics](docs/ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset authoring templates](docs/ASSET_AUTHORING_TEMPLATES.md)
 - [Content family authoring](docs/CONTENT_FAMILY_AUTHORING.md)

--- a/docs/ASSET_AUTHORING_TEMPLATES.md
+++ b/docs/ASSET_AUTHORING_TEMPLATES.md
@@ -25,7 +25,7 @@ content-first starting points for visual/content authoring.
 Each template includes:
 
 - `experience.toml` as a minimal selected experience wrapper;
-- `content.manifest` with active manifest v1 declarations;
+- `content.manifest` with active manifest v1 declarations, or a small root manifest with explicit `includes = [...]` for modular packs;
 - `content/textures/example_16.png`;
 - `content/textures/example_32.png`;
 - material declarations;
@@ -50,10 +50,40 @@ The script verifies:
 - manifest sha256 values match source files;
 - each template passes `freven_boot content-assets check`.
 
+## Modular template layout
+
+For larger templates and future Vanilla-style visual packs, use this layout:
+
+    content.manifest
+    content/
+      textures/terrain.toml
+      materials/terrain.toml
+      models/blocks.toml
+      visuals/blocks.toml
+      families/rocks.toml
+      tags/terrain.toml
+
+The root manifest is an explicit index:
+
+    schema = 1
+    includes = [
+      "content/textures/terrain.toml",
+      "content/materials/terrain.toml",
+      "content/models/blocks.toml",
+      "content/visuals/blocks.toml",
+      "content/families/rocks.toml",
+      "content/tags/terrain.toml",
+    ]
+
+Do not use directory scanning, generated cache, or renderer/internal ids as
+authoring template source. See [Modular content authoring](MODULAR_CONTENT_AUTHORING.md).
+
 ## Use a template
 
 Copy a template directory into an instance `experiences/` directory, then run:
 
+    freven_boot content-assets update-sha --instance <instance> --experience <template_id>
+    freven_boot content-assets update-sha --instance <instance> --experience <template_id> --write
     freven_boot content-assets check --instance <instance> --experience <template_id>
     freven_boot content-assets explain --instance <instance> --experience <template_id>
     freven_boot content-assets inspect --instance <instance> --experience <template_id>
@@ -63,7 +93,7 @@ Before shipping:
 
 - replace `example.asset.*` ids and keys with your namespace;
 - replace example PNGs with real texture bytes;
-- update sha256 values in `content.manifest`;
+- run `freven_boot content-assets update-sha --instance <instance> --experience <template_id> --write` after replacing texture bytes;
 - keep generated cache outside authored source;
 - keep active runtime config for tuning, not visual definitions.
 
@@ -72,6 +102,9 @@ Before shipping:
 These templates are designed to avoid common diagnostics from
 [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md):
 
+- missing include files or include cycles;
+- duplicate semantic keys across included files;
+- stale or missing texture sha256 fields;
 - missing texture files;
 - bad texture paths;
 - missing material texture references;
@@ -87,6 +120,7 @@ not load.
 - [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
 
 - [Project templates](PROJECT_TEMPLATES.md)
+- [Modular content authoring](MODULAR_CONTENT_AUTHORING.md)
 
 ## Family templates
 

--- a/docs/ASSET_PIPELINE_DIAGNOSTICS.md
+++ b/docs/ASSET_PIPELINE_DIAGNOSTICS.md
@@ -275,6 +275,10 @@ DevKit-friendly asset diagnostics must cover at least these cases:
 | Missing texture key | material/visual key, field, referenced texture key, owner layer, suggested declaration |
 | Missing material key | visual/model/block key, field or slot, referenced material key, owner layer |
 | Missing model key | visual key, field, referenced model key, owner layer |
+| Missing include file | root manifest path, declaring file, include path, resolved path, content-root boundary |
+| Include cycle | root manifest path, include stack, repeated file, suggested ownership split |
+| Duplicate semantic key across includes | semantic kind, key, first source file, second source file, field path when known |
+| Stale texture sha256 | texture key, asset path, manifest/include source file, old hash, new hash, `content-assets update-sha --write` hint |
 | Missing texture file | texture key, expected package-relative path, manifest/source file |
 | Bad image format | texture key, path, accepted formats |
 | Unsupported texture size | texture key, actual dimensions, active profile, accepted dimensions |
@@ -323,6 +327,34 @@ render layer: opaque
 expected: blend materials normally use render_layer = "transparent"
 fix: change render_layer to "transparent", or change alpha_mode to "opaque".
 ```
+
+Example modular include failure:
+
+    error FVK-CONTENT-INCLUDE-MISSING
+    root manifest: experiences/example.visual_pack/content.manifest
+    declared in: experiences/example.visual_pack/content.manifest
+    include: content/textures/terrain.toml
+    resolved path: experiences/example.visual_pack/content/textures/terrain.toml
+    fix: create the included file, remove the include, or correct the path.
+
+Example include cycle:
+
+    error FVK-CONTENT-INCLUDE-CYCLE
+    root manifest: experiences/example.visual_pack/content.manifest
+    include stack:
+      content.manifest
+      content/families/rocks.toml
+      content/families/common.toml
+      content/families/rocks.toml
+    fix: make one file own the shared declarations and include it from only one direction.
+
+Example stale hash:
+
+    error FVK-ASSET-SHA256-MISMATCH
+    texture key: example.visual:textures/block/stone
+    declared in: experiences/example.visual_pack/content/textures/terrain.toml
+    asset path: content/textures/stone.png
+    fix: run `freven_boot content-assets update-sha --instance <instance> --experience <experience_id> --write` after intentionally changing the texture bytes.
 
 Example bridge limitation:
 
@@ -400,6 +432,13 @@ plan for the selected experience or stack.
 Use it when authored texture, material, model, shader/effect, block visual, or
 content patch data does not load.
 
+`freven_boot content-assets update-sha` reports and fixes missing or stale texture hashes from declared texture asset bytes:
+
+    ./freven_boot content-assets update-sha --instance <instance> --experience <experience_id>
+    ./freven_boot content-assets update-sha --instance <instance> --experience <experience_id> --write
+
+It must use declared texture entries only. It must not import arbitrary files by scanning the filesystem.
+
 `freven_boot content-assets explain` prints the resolved graph:
 
 ```bash
@@ -416,8 +455,11 @@ specifically debugging provider declarations.
 
 ## Relationship to other rc10 DevKit issues
 
-- frevenengine/freven-boot#86 implements the current `content-assets check` and
+- frevenengine/freven-boot#86 implements the `content-assets check` and
   `content-assets explain` command surface for resolved visual load plans.
+- frevenengine/freven-boot#99 implements `content-assets update-sha` for
+  declared texture hash authoring.
+- frevenengine/freven-engine#319 implements modular manifest include expansion.
 - frevenengine/freven-boot#87 fixes the `providers check` Material Registry
   v1 bridge path by passing the resolved registry into provider validation.
 - frevenengine/freven-boot#89 adds the current CLI asset inspector surface

--- a/docs/CONTENT_FAMILY_AUTHORING.md
+++ b/docs/CONTENT_FAMILY_AUTHORING.md
@@ -50,7 +50,7 @@ The author-facing order is:
 
 1. resolve the selected experience or stack;
 2. collect effective content layers;
-3. load each `content.manifest`;
+3. load each `content.manifest`, including explicit modular `includes = [...]` files;
 4. validate authored declarations, including `[[families]]`;
 5. expand families into normal semantic entries;
 6. validate generated references after expansion;
@@ -171,6 +171,7 @@ renderer or mesh internals in author source.
 ## Related docs
 
 - [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
+- [Modular content authoring](MODULAR_CONTENT_AUTHORING.md)
 - [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)
 - [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset inspector / devtools](ASSET_INSPECTOR_DEVTOOLS.md)

--- a/docs/DATA_CONTENT_ASSET_WORKFLOW.md
+++ b/docs/DATA_CONTENT_ASSET_WORKFLOW.md
@@ -110,15 +110,38 @@ Examples of content data:
 
 Current DevKit/Boot experience content is selected through:
 
-```toml
-[content]
-root = "content"
-manifest = "content.manifest"
-```
+    [content]
+    root = "content"
+    manifest = "content.manifest"
 
 A stack should inherit base content unless a layer explicitly declares a content
 overlay. A standalone/product-owned experience should declare its own content
 root when it owns content.
+
+### Modular content manifests
+
+Small packs can keep all declarations in one `content.manifest`. Larger packs
+should use the root manifest as an explicit deterministic source index:
+
+    schema = 1
+    includes = [
+      "content/textures/terrain.toml",
+      "content/materials/terrain.toml",
+      "content/models/blocks.toml",
+      "content/visuals/blocks.toml",
+      "content/families/rocks.toml",
+      "content/tags/terrain.toml",
+    ]
+
+Included files are authored source content. They are not generated cache,
+runtime ids, renderer slots, or hidden imports.
+
+Include paths are resolved relative to the declaring file. They are ordered
+explicitly by the author; DevKit does not scan directories, expand globs, or use
+filesystem order as content order.
+
+Use [Modular content authoring](MODULAR_CONTENT_AUTHORING.md) for the full
+layout, include rules, troubleshooting shape, and hash-update workflow.
 
 ### Asset files
 
@@ -179,6 +202,8 @@ Commands available today:
 ./freven_boot content-assets explain --instance <instance> --experience <experience_id>
 ./freven_boot content-assets inspect --instance <instance> --experience <experience_id>
 ./freven_boot content-assets watch --instance <instance> --experience <experience_id>
+./freven_boot content-assets update-sha --instance <instance> --experience <experience_id>
+./freven_boot content-assets update-sha --instance <instance> --experience <experience_id> --write
 ```
 
 Use `content-assets check` before launch when a texture, material, model, block
@@ -192,6 +217,10 @@ family expansion output before launch.
 Use `content-assets explain` when you need to inspect resolved content layers,
 effective assets, dependency edges, shadowed overrides, internal slots, and the
 load-plan fingerprint.
+
+Use `content-assets update-sha` after adding or editing texture bytes. The
+default dry-run reports missing or stale hashes. Add `--write` to update the
+authored manifest or included source file that owns the texture declaration.
 
 Use `content-assets watch` during development when you want a conservative
 edit/check loop for texture, material, model, visual, or content source changes.
@@ -276,6 +305,25 @@ manifest = "content.manifest"
 
 The bundled core mod can provide behavior, providers, or runtime services. The
 content root owns authored definitions and referenced resources.
+
+## Canonical modular layout
+
+For larger visual/content packs, prefer:
+
+    experiences/example.visual_pack/
+      experience.toml
+      content.manifest
+      content/
+        textures/terrain.toml
+        materials/terrain.toml
+        models/blocks.toml
+        visuals/blocks.toml
+        families/rocks.toml
+        tags/terrain.toml
+
+The root `content.manifest` should stay small and list only `schema` plus
+explicit `includes = [...]`. Vanilla's rc10 split should become the first-party
+reference for this layout, but it should not be a special engine-only path.
 
 ## Common mistakes
 

--- a/docs/FRIENDLY_DIAGNOSTICS.md
+++ b/docs/FRIENDLY_DIAGNOSTICS.md
@@ -23,7 +23,7 @@ Current Boot diagnostics include friendly wrappers for:
 | Load-plan construction failure | provider/content commands | selected experience manifest, active mods, provider defaults, content roots |
 | Provider default mismatch | `providers check/list/explain` | `[defaults]` / `[layers.defaults]` provider keys |
 | Material Registry bridge/content graph | `providers check`, then `content-assets check` | visual content/material declarations |
-| Content/assets graph failure | `content-assets check/explain/inspect/watch` | `content.manifest`, texture/material/model/effect declarations and files |
+| Content/assets graph failure | `content-assets check/explain/inspect/watch/update-sha` | `content.manifest`, included content source files, texture/material/model/effect declarations and files |
 
 The Boot-side implementation landed in frevenengine/freven-boot#91.
 
@@ -159,7 +159,7 @@ Use diagnostics to fix the owning source:
 - `experience.toml` / `experience.stack.toml`: selected mods, defaults, content
   root, stack overlays;
 - `config.schema.toml` and active config: tunable runtime settings;
-- `content/` and `content.manifest`: authored gameplay/visual content source;
+- `content/` and `content.manifest`: authored gameplay/visual content source, including explicit modular `includes = [...]` source files;
 - generated cache: rebuildable output;
 - `worlds/`: runtime save state.
 
@@ -171,6 +171,7 @@ Use diagnostics to fix the owning source:
 - [First Wasm mod](FIRST_WASM_MOD.md)
 - [Provider selection authoring](PROVIDER_AUTHORING.md)
 - [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
+- [Modular content authoring](MODULAR_CONTENT_AUTHORING.md)
 - [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Mod DevTools v1](MOD_DEVTOOLS.md)
 - [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/MODULAR_CONTENT_AUTHORING.md
+++ b/docs/MODULAR_CONTENT_AUTHORING.md
@@ -1,0 +1,227 @@
+# Modular content authoring
+
+Modular content manifests let large content packs stay readable without changing
+the semantic content model.
+
+The root `content.manifest` is an explicit deterministic source index. Included
+files are authored source files. They are not generated cache, not runtime ids,
+and not renderer-internal data.
+
+Use this workflow when one manifest becomes hard to review, when multiple
+authors are editing different content areas, or when a content pack naturally
+splits into textures, materials, models, visuals, families, and tags.
+
+## Recommended layout
+
+For a standalone experience or content-pack style project:
+
+    experiences/example.visual_pack/
+      experience.toml
+      content.manifest
+      content/
+        textures/
+          terrain.toml
+          stone.png
+          dirt.png
+        materials/
+          terrain.toml
+        models/
+          blocks.toml
+        visuals/
+          blocks.toml
+        families/
+          rocks.toml
+          soil_grass.toml
+        tags/
+          terrain.toml
+
+The experience still selects the same content boundary:
+
+    [content]
+    root = "content"
+    manifest = "content.manifest"
+
+The root manifest should stay small and explicit:
+
+    schema = 1
+    includes = [
+      "content/textures/terrain.toml",
+      "content/materials/terrain.toml",
+      "content/models/blocks.toml",
+      "content/visuals/blocks.toml",
+      "content/families/rocks.toml",
+      "content/tags/terrain.toml",
+    ]
+
+Include paths are resolved relative to the file that declares them. In the
+current DevKit layout above, `content.manifest` sits next to `content/`, so the
+root includes usually start with `content/...`.
+
+If a manifest file inside `content/families/rocks.toml` includes another nearby
+file, that include is relative to `content/families/rocks.toml`.
+
+## Single-file vs modular
+
+Keep a single `content.manifest` when:
+
+- the pack is tiny;
+- it has one or two declarations;
+- the content is a throwaway prototype;
+- splitting would make review harder, not easier.
+
+Split into modular files when:
+
+- the manifest mixes textures, materials, models, visuals, families, and tags;
+- texture/material churn causes large unrelated diffs;
+- generated family declarations make the root file hard to scan;
+- Vanilla or a standalone product needs a stable long-term reference layout;
+- different people own different content areas.
+
+Both forms expand into the same semantic content model. The runtime should not
+expose include files as ids, renderer slots, atlas pages, or cache paths.
+
+## Include rules
+
+Includes are explicit ordered paths, not filesystem traversal.
+
+Allowed:
+
+    includes = [
+      "content/textures/terrain.toml",
+      "content/materials/terrain.toml",
+    ]
+
+Not allowed:
+
+    includes = ["../other_pack/content.manifest"]
+    includes = ["/absolute/path/content.manifest"]
+    includes = ["content/generated/cache.toml"]
+    includes = ["content/textures/"] # directory include
+
+Rules:
+
+- no hidden directory scanning;
+- no glob imports;
+- no absolute paths;
+- no `..` traversal;
+- no directory includes;
+- no content-root escapes;
+- no include cycles;
+- no generated cache as authored source.
+
+The order in `includes = [...]` is the authoring order. Do not rely on filesystem
+listing order.
+
+## Texture sha256 workflow
+
+Texture hashes remain strict because they support reproducible validation,
+fingerprints, packaging, and stale-asset diagnostics. Authors should not compute
+or paste hashes by hand.
+
+After adding or editing texture bytes, run:
+
+    freven_boot content-assets update-sha \
+      --instance <instance> \
+      --experience <experience_id>
+
+That dry-run prints what would change. To update authored source files:
+
+    freven_boot content-assets update-sha \
+      --instance <instance> \
+      --experience <experience_id> \
+      --write
+
+Useful filters:
+
+    freven_boot content-assets update-sha \
+      --instance <instance> \
+      --experience <experience_id> \
+      --missing-only \
+      --write
+
+    freven_boot content-assets update-sha \
+      --instance <instance> \
+      --experience <experience_id> \
+      --stale-only \
+      --write
+
+The tool uses declared texture entries only. It does not import random files
+from the filesystem. For modular manifests, it updates the included source file
+that owns the texture declaration instead of rewriting the root index.
+
+## Validation loop
+
+Use this loop while authoring:
+
+    freven_boot content-assets update-sha --instance <instance> --experience <experience_id>
+    freven_boot content-assets update-sha --instance <instance> --experience <experience_id> --write
+    freven_boot content-assets check --instance <instance> --experience <experience_id>
+    freven_boot content-assets explain --instance <instance> --experience <experience_id>
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id>
+    freven_boot content-assets watch --instance <instance> --experience <experience_id> --once
+
+Use `inspect --kind generated` for content family output:
+
+    freven_boot content-assets inspect \
+      --instance <instance> \
+      --experience <experience_id> \
+      --kind generated
+
+## Diagnostics authors should expect
+
+Good diagnostics should identify:
+
+- selected experience or stack;
+- selected content layer;
+- root manifest path;
+- included source file path;
+- include stack when there is a cycle;
+- semantic kind and key, such as texture/material/model/visual/family/tag;
+- field path when available, such as `textures[].sha256`;
+- old and new sha256 when a texture hash is stale;
+- the next focused command.
+
+Common examples:
+
+    error: missing include
+    root manifest: experiences/example.visual_pack/content.manifest
+    include: content/textures/terrain.toml
+    fix: create the file, remove the include, or correct the path.
+
+    error: include cycle
+    include stack:
+      content.manifest
+      content/families/rocks.toml
+      content/families/common.toml
+      content/families/rocks.toml
+    fix: make one file own the shared declarations and include it from only one direction.
+
+    error: duplicate semantic key
+    key: example.visual:textures/block/stone
+    first source: content/textures/terrain.toml
+    second source: content/textures/overrides.toml
+    fix: remove the duplicate, rename one key, or use the proper layer override mechanism.
+
+    error: stale sha256
+    texture key: example.visual:textures/block/stone
+    declared in: content/textures/terrain.toml
+    asset path: content/textures/stone.png
+    fix: run content-assets update-sha --write after intentionally changing the texture bytes.
+
+## Vanilla reference
+
+The eventual Vanilla split should follow this same shape: a small explicit root
+manifest plus stable included files for terrain textures, materials, models,
+visuals, families, and tags.
+
+Vanilla is a reference for first-party content organization, not a special engine
+path. Mods and standalone products should use the same author-facing rules.
+
+## Related docs
+
+- [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
+- [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)
+- [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
+- [Content family authoring](CONTENT_FAMILY_AUTHORING.md)
+- [Asset inspector / devtools](ASSET_INSPECTOR_DEVTOOLS.md)
+- [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/PROJECT_TEMPLATES.md
+++ b/docs/PROJECT_TEMPLATES.md
@@ -59,7 +59,7 @@ shader/material/visual-style boundary.
 - `experience.toml` and `experience.stack.toml` select mods, defaults, content roots, and stack overlays;
 - `config.schema.toml` defines tunable runtime settings;
 - active config stores user/admin-selected values;
-- `content/` and `content.manifest` store authored gameplay/visual content source;
+- `content/` and `content.manifest` store authored gameplay/visual content source; larger packs may use a small root manifest with explicit `includes = [...]` modular files;
 - generated cache is rebuildable output;
 - `worlds/` is runtime save state.
 
@@ -235,6 +235,7 @@ Use:
 - [Getting started](GETTING_STARTED.md)
 - [First Wasm mod](FIRST_WASM_MOD.md)
 - [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
+- [Modular content authoring](MODULAR_CONTENT_AUTHORING.md)
 - [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)
 - [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset inspector / devtools](ASSET_INSPECTOR_DEVTOOLS.md)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -68,7 +68,7 @@ First identify the boundary that owns the fix:
 - `mod.toml` is manifest/capability metadata.
 - `config.schema.toml` and active `[config."<mod_id>"]` values are runtime
   configuration.
-- `content/` and `content.manifest` are authored gameplay/visual content source.
+- `content/` and `content.manifest` are authored gameplay/visual content source. For large packs, `content.manifest` may be a small explicit `includes = [...]` index over modular source files.
 - asset files are resource bytes referenced by content declarations.
 - generated cache is rebuildable output.
 - `worlds/` is save/world state, not shipped defaults.
@@ -93,6 +93,50 @@ Common examples:
   the resolved Material Registry before provider validation. If this still
   fails, run `freven_boot content-assets check` first because the problem is
   now in the content/assets graph, not provider declaration resolution.
+
+## Modular content manifest include fails
+
+If a content/assets command reports a missing include, invalid include path,
+include cycle, or duplicate semantic key, start from the root manifest selected
+by the experience:
+
+    [content]
+    root = "content"
+    manifest = "content.manifest"
+
+Check that:
+
+- `includes = [...]` paths are explicit and ordered;
+- include paths are relative to the file that declares them;
+- the root `content.manifest` sits next to `content/`, so root includes usually
+  look like `content/textures/terrain.toml`;
+- included files stay inside the selected content root;
+- no include uses an absolute path, `..`, a directory, or generated cache;
+- no two included files declare the same texture/material/model/visual/family/tag
+  key unless that is expressed through a proper selected layer override;
+- family declarations and generated outputs still validate after expansion.
+
+Run:
+
+    ./freven_boot content-assets check --instance <instance> --experience <experience_id>
+    ./freven_boot content-assets explain --instance <instance> --experience <experience_id>
+
+See [Modular content authoring](MODULAR_CONTENT_AUTHORING.md).
+
+## Texture sha256 is missing or stale
+
+If `content-assets check` reports a missing or stale texture hash, do not compute
+and paste hashes by hand. First dry-run:
+
+    ./freven_boot content-assets update-sha --instance <instance> --experience <experience_id>
+
+Then write the exact authored manifest or included source file that owns the
+texture declaration:
+
+    ./freven_boot content-assets update-sha --instance <instance> --experience <experience_id> --write
+
+The command uses declared texture entries only. It does not scan random files
+into content.
 
 ## Texture, material, model, or content patch does not load
 
@@ -138,6 +182,7 @@ Start with:
 ## Related docs
 
 - [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
+- [Modular content authoring](MODULAR_CONTENT_AUTHORING.md)
 
 ## Content family expansion fails
 


### PR DESCRIPTION
## Summary

Documents the DevKit modular content authoring workflow for freven-devkit#108.

This surfaces the new SDK/engine/boot capabilities from:

- frevenengine/freven-engine#319 — explicit modular manifest include expansion
- frevenengine/freven-boot#99 — `content-assets update-sha` authoring helper

## What changed

- Added `docs/MODULAR_CONTENT_AUTHORING.md` as the canonical author-facing guide.
- Documented the recommended modular layout:
  - `textures/`
  - `materials/`
  - `models/`
  - `visuals/`
  - `families/`
  - `tags/`
- Explained when to keep a single `content.manifest` vs split into included files.
- Documented explicit deterministic `includes = [...]` and that this is not glob/directory traversal.
- Documented that modular files are authored source, not generated cache, runtime ids, or renderer internals.
- Updated asset workflow/templates docs to point authors at `content-assets update-sha --write` instead of manual sha256 editing.
- Added diagnostics/troubleshooting guidance for:
  - missing include files;
  - include cycles;
  - duplicate semantic keys across included files;
  - invalid include/source paths;
  - missing or stale texture sha256.
- Linked the new modular authoring guide from README and related DevKit docs.
- Clarified that Vanilla's split should become a reference layout, not a special engine path.

## Notes

This repository currently contains documentation and issue tracking only; there is no checked-in `templates/` or `scripts/` directory in this repo. The PR therefore updates the DevKit template contract and author-facing workflow docs rather than adding dead template files here.

## Validation

- git --no-pager diff --check
- markdown local link check
- coverage grep for `includes = [...]`, `content-assets update-sha`, include diagnostics, stale sha256, generated cache, and Vanilla reference

Closes frevenengine/freven-devkit#108
