### PR TITLE
Document content authoring profile workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Include:
 - [First Wasm mod](docs/FIRST_WASM_MOD.md)
 - [Data/content asset workflow](docs/DATA_CONTENT_ASSET_WORKFLOW.md)
 - [Modular content authoring](docs/MODULAR_CONTENT_AUTHORING.md)
+- [Content authoring profiles](docs/CONTENT_AUTHORING_PROFILES.md)
 - [Asset pipeline diagnostics](docs/ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset authoring templates](docs/ASSET_AUTHORING_TEMPLATES.md)
 - [Content family authoring](docs/CONTENT_FAMILY_AUTHORING.md)

--- a/docs/ASSET_AUTHORING_TEMPLATES.md
+++ b/docs/ASSET_AUTHORING_TEMPLATES.md
@@ -78,6 +78,8 @@ The root manifest is an explicit index:
 Do not use directory scanning, generated cache, or renderer/internal ids as
 authoring template source. See [Modular content authoring](MODULAR_CONTENT_AUTHORING.md).
 
+When a selected game provides a higher-level authoring profile, template docs should name the profile id and explain the `freven_boot content compile` step. For Vanilla-style block authoring, the intended profile is `freven.vanilla:blocktypes_v1`; low-level visual templates may continue to use `freven.core:canonical_manifest_v1` directly. See [Content authoring profiles](CONTENT_AUTHORING_PROFILES.md).
+
 ## Use a template
 
 Copy a template directory into an instance `experiences/` directory, then run:

--- a/docs/CONTENT_AUTHORING_PROFILES.md
+++ b/docs/CONTENT_AUTHORING_PROFILES.md
@@ -1,0 +1,234 @@
+# Content authoring profiles
+
+Freven has two layers of content authoring:
+
+1. the canonical Freven content graph;
+2. game-owned authoring profiles that compile or expand into that graph.
+
+The canonical graph is the stable backend boundary used by engine/runtime
+systems. A game-owned profile is a friendlier source format selected by a game,
+mode, experience, or modding ecosystem.
+
+This keeps the engine flexible:
+
+- Vanilla can provide a Vintage-Story-style blocktypes/worldproperties/shapes
+  workflow;
+- another game can provide a Factorio-like prototype workflow;
+- another game can provide a Minecraft-like resource-pack convention;
+- a standalone product can use the canonical graph directly;
+- a custom game can define its own profile without changing engine runtime code.
+
+## Canonical graph vs authoring profile
+
+The canonical graph contains low-level semantic declarations such as:
+
+- textures;
+- materials;
+- models;
+- block visual bindings;
+- content families;
+- block tags;
+- future canonical gameplay/content declarations.
+
+A game-owned authoring profile may contain friendlier source files such as:
+
+- blocktypes;
+- worldproperties;
+- shapes;
+- prototypes;
+- recipes;
+- loot tables;
+- texture aliases;
+- by-type rules;
+- game-specific behavior references.
+
+The profile compiler maps the friendly source into canonical declarations.
+
+The engine consumes the canonical graph. It must not hardcode Vanilla's
+blocktype schema, folder layout, or modding conventions.
+
+## Command workflow
+
+Boot exposes the profile bridge through:
+
+    freven_boot content compile \
+      --instance <instance> \
+      --experience <experience_id> \
+      --profile <profile_id> \
+      --explain
+
+The default profile is:
+
+    freven.core:canonical_manifest_v1
+
+That profile is a passthrough for low-level canonical manifests. It validates the
+resolved canonical graph and explains the compile boundary, but it does not need
+to generate new source files because the authored files are already canonical.
+
+For profile compilers that support materialized output, write mode is explicit:
+
+    freven_boot content compile \
+      --instance <instance> \
+      --experience <experience_id> \
+      --profile <profile_id> \
+      --output <output_dir> \
+      --write
+
+Generated output is not the source of truth unless the selected profile says so.
+For normal game-owned profiles, source files remain under the game/profile-owned
+authoring layout, and generated canonical files are rebuildable output.
+
+After compiling or validating the profile boundary, use the existing graph tools:
+
+    freven_boot content-assets check --instance <instance> --experience <experience_id>
+    freven_boot content-assets explain --instance <instance> --experience <experience_id>
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id>
+    freven_boot content-assets inspect --instance <instance> --experience <experience_id> --kind generated
+
+Texture hash maintenance remains:
+
+    freven_boot content-assets update-sha --instance <instance> --experience <experience_id>
+    freven_boot content-assets update-sha --instance <instance> --experience <experience_id> --write
+
+## Vanilla profile
+
+The intended Vanilla profile id is:
+
+    freven.vanilla:blocktypes_v1
+
+The target Vanilla layout is:
+
+    content/
+      blocktypes/
+        rock.toml
+        soil.toml
+        grass.toml
+        glass.toml
+      worldproperties/
+        rock.toml
+        fertility.toml
+        grass_coverage.toml
+        color.toml
+      shapes/
+        block/
+          cube.toml
+          cube_faces.toml
+          topsoil.toml
+          glass_framed.toml
+      textures/
+        terrain.toml
+        tint.toml
+      tags/
+        terrain.toml
+
+This profile is Vanilla-owned. It is not an engine-global convention.
+
+A Vanilla mod should usually target the Vanilla profile when it wants to edit or
+add Vanilla-style blocks. A low-level content pack may target the canonical graph
+directly when it intentionally wants exact material/model/visual declarations.
+
+## Current rc10 state
+
+The current rc10 Vanilla content has already moved away from one giant manifest
+into semantic modular source files. Those files are still canonical manifest
+source organized by meaning, not the full high-level Vanilla profile compiler.
+
+That means:
+
+- `content/blocktypes/*.toml` in current Vanilla are semantic canonical source
+  files;
+- future `freven.vanilla:blocktypes_v1` source may become higher level;
+- `freven_boot content compile --profile freven.vanilla:blocktypes_v1` is the
+  intended compiler bridge once the Vanilla compiler lands;
+- the engine should still only see the canonical content graph.
+
+## Choosing the right layer
+
+Use a game-owned profile when:
+
+- the selected game documents one;
+- the source files are easier for that game's modders;
+- you want by-type rules, variant groups, or profile-local conventions;
+- diagnostics should point at game concepts like blocktype/worldproperty/shape.
+
+Use the canonical graph directly when:
+
+- you are building a tiny content pack;
+- you need exact texture/material/model/visual control;
+- the game has no higher-level profile;
+- you are authoring reusable low-level visual assets;
+- you are testing engine/runtime content contracts.
+
+Do not put renderer/runtime ids, atlas coordinates, GPU handles, generated cache
+paths, or engine slots in author-facing profile source.
+
+## How mods know what profile they target
+
+The selected experience, stack, or modding guide should document the profile id.
+
+For Vanilla-style mods, use:
+
+    freven.vanilla:blocktypes_v1
+
+For low-level canonical content, use:
+
+    freven.core:canonical_manifest_v1
+
+Future templates may include profile metadata in their README or experience
+source. Until then, the profile id should be passed explicitly to
+`freven_boot content compile`.
+
+## Diagnostics authors should expect
+
+Good profile diagnostics should report:
+
+- selected experience or stack;
+- selected profile id;
+- source file;
+- source kind, such as blocktype, worldproperty, shape, or prototype;
+- source field path;
+- generated canonical declaration kind;
+- generated canonical key;
+- first and second source files for duplicate generated keys;
+- the next focused command.
+
+Example:
+
+    error: duplicate generated material key
+    profile: freven.vanilla:blocktypes_v1
+    source: content/blocktypes/soil.toml
+    field: textures.grass_top
+    generated declaration: materials
+    key: freven.vanilla:block/grass_normal_top
+    first source: content/blocktypes/grass.toml
+    second source: content/blocktypes/soil.toml
+    fix: move the shared material to a common source file or rename the generated key
+
+Example unsupported profile:
+
+    error: content compile profile 'freven.vanilla:blocktypes_v1' is declared but not implemented yet
+    fix: use freven.core:canonical_manifest_v1 for current canonical manifests, or wait for the Vanilla profile compiler
+
+## Relationship to templates
+
+This repository currently documents template contracts. Packaged DevKit templates
+may live in the Boot distribution.
+
+Template docs should distinguish:
+
+- project templates for experience/mod/stack shape;
+- asset templates for low-level canonical content examples;
+- game-owned profile templates for friendly game-specific authoring.
+
+Do not add fake template files here just to satisfy a docs issue. If the repo
+does not contain a checked-in template catalog, document the intended template
+contract and point to the packaged DevKit/Boot template location.
+
+## Related docs
+
+- [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
+- [Modular content authoring](MODULAR_CONTENT_AUTHORING.md)
+- [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)
+- [Project templates](PROJECT_TEMPLATES.md)
+- [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
+- [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/DATA_CONTENT_ASSET_WORKFLOW.md
+++ b/docs/DATA_CONTENT_ASSET_WORKFLOW.md
@@ -198,6 +198,7 @@ Commands available today:
 ./freven_boot config explain --instance <instance> --experience <experience_id>
 ./freven_boot providers check --instance <instance> --experience <experience_id>
 ./freven_boot providers explain --instance <instance> --experience <experience_id>
+./freven_boot content compile --instance <instance> --experience <experience_id> --profile freven.core:canonical_manifest_v1 --explain
 ./freven_boot content-assets check --instance <instance> --experience <experience_id>
 ./freven_boot content-assets explain --instance <instance> --experience <experience_id>
 ./freven_boot content-assets inspect --instance <instance> --experience <experience_id>
@@ -205,6 +206,8 @@ Commands available today:
 ./freven_boot content-assets update-sha --instance <instance> --experience <experience_id>
 ./freven_boot content-assets update-sha --instance <instance> --experience <experience_id> --write
 ```
+
+Use `content compile` when a selected game/mode authoring profile needs to be validated or compiled into the canonical content graph. The default `freven.core:canonical_manifest_v1` profile is a passthrough for current canonical manifests; game-owned profiles such as `freven.vanilla:blocktypes_v1` are opt-in and owned by their game/profile.
 
 Use `content-assets check` before launch when a texture, material, model, block
 visual, or content patch does not load. It resolves the selected experience or

--- a/docs/ENGINE_VANILLA_OWNERSHIP.md
+++ b/docs/ENGINE_VANILLA_OWNERSHIP.md
@@ -27,7 +27,7 @@ for debugging.
 | --- | --- | --- |
 | Engine/runtime | renderer implementation, asset loading, material registry resolution, fallback rendering, generated renderer/cache output, diagnostics plumbing | Vanilla block library, Vanilla visual style, mod-authored schemas, stable author namespaces |
 | SDK | public schemas, stable `namespace:path` keys, guest APIs, material/model/visual/effect contract vocabulary | renderer slots, Bevy/wgpu handles, Vanilla content, product-specific style |
-| DevKit / Boot | validation commands, inspectors, templates, packaging, author-facing diagnostics, resolved load-plan explanation | first-party content policy, renderer implementation, hidden gameplay defaults |
+| DevKit / Boot | validation commands, inspectors, templates, packaging, author-facing diagnostics, resolved load-plan explanation, content compile command surface | first-party content policy, renderer implementation, hidden gameplay defaults, engine-global Vanilla schema |
 | Vanilla | first-party blocks, tags, materials, textures, visual style, default providers, reference gameplay integration | engine/platform behavior, mandatory base for all games, SDK schemas |
 | Standalone product | product identity, bundled default experience, product-owned content/style/providers/config | implicit dependency on Vanilla, reuse of shipped proof experience as authoring contract |
 | Mod | runtime behavior, providers, config schema, package identity, declared content/assets | unrestricted engine access, silent ownership of another namespace |
@@ -223,6 +223,7 @@ If any answer is no, the feature is probably crossing an ownership boundary.
 - [Project templates](PROJECT_TEMPLATES.md)
 - [Data/content asset workflow](DATA_CONTENT_ASSET_WORKFLOW.md)
 - [Asset authoring templates](ASSET_AUTHORING_TEMPLATES.md)
+- [Content authoring profiles](CONTENT_AUTHORING_PROFILES.md)
 - [Asset pipeline diagnostics](ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset inspector / devtools](ASSET_INSPECTOR_DEVTOOLS.md)
 - [Asset/content hot reload](ASSET_CONTENT_HOT_RELOAD.md)

--- a/docs/FRIENDLY_DIAGNOSTICS.md
+++ b/docs/FRIENDLY_DIAGNOSTICS.md
@@ -24,6 +24,7 @@ Current Boot diagnostics include friendly wrappers for:
 | Provider default mismatch | `providers check/list/explain` | `[defaults]` / `[layers.defaults]` provider keys |
 | Material Registry bridge/content graph | `providers check`, then `content-assets check` | visual content/material declarations |
 | Content/assets graph failure | `content-assets check/explain/inspect/watch/update-sha` | `content.manifest`, included content source files, texture/material/model/effect declarations and files |
+| Authoring profile compile failure | `content compile --explain`, then `content-assets check` | game-owned source files such as blocktypes/worldproperties/shapes and generated canonical declarations |
 
 The Boot-side implementation landed in frevenengine/freven-boot#91.
 
@@ -166,6 +167,7 @@ Use diagnostics to fix the owning source:
 ## Related docs
 
 - [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
+- [Content authoring profiles](CONTENT_AUTHORING_PROFILES.md)
 
 - [Getting started](GETTING_STARTED.md)
 - [First Wasm mod](FIRST_WASM_MOD.md)

--- a/docs/MODULAR_CONTENT_AUTHORING.md
+++ b/docs/MODULAR_CONTENT_AUTHORING.md
@@ -80,6 +80,8 @@ Split into modular files when:
 Both forms expand into the same semantic content model. The runtime should not
 expose include files as ids, renderer slots, atlas pages, or cache paths.
 
+For game-specific high-level source formats, use [Content authoring profiles](CONTENT_AUTHORING_PROFILES.md). A profile may compile friendlier source such as Vanilla blocktypes/worldproperties into the same canonical graph, while modular manifests remain the low-level canonical source format.
+
 ## Include rules
 
 Includes are explicit ordered paths, not filesystem traversal.

--- a/docs/PROJECT_TEMPLATES.md
+++ b/docs/PROJECT_TEMPLATES.md
@@ -207,6 +207,7 @@ Validate with:
 
 After copying any project template into an instance:
 
+    freven_boot content compile --instance <instance> --experience <experience_id> --profile freven.core:canonical_manifest_v1 --explain
     freven_boot config check --instance <instance> --experience <experience_id>
     freven_boot providers explain --instance <instance> --experience <experience_id>
     freven_boot content-assets check --instance <instance> --experience <experience_id>
@@ -227,6 +228,7 @@ Use:
 
 - project templates for project shape;
 - asset authoring templates for texture/material/model/content examples;
+- content authoring profiles for game-owned source schemas such as `freven.vanilla:blocktypes_v1`;
 - standalone product generator for product-owned games;
 - `FIRST_WASM_MOD.md` for a longer first Wasm walkthrough.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -94,6 +94,30 @@ Common examples:
   fails, run `freven_boot content-assets check` first because the problem is
   now in the content/assets graph, not provider declaration resolution.
 
+## Content authoring profile compile fails
+
+If `freven_boot content compile` reports an unknown or unsupported profile, check
+which authoring layer you intended to use.
+
+Use the canonical passthrough profile for current low-level manifests:
+
+    ./freven_boot content compile --instance <instance> --experience <experience_id> --profile freven.core:canonical_manifest_v1 --explain
+
+Use a game-owned profile only when the selected game or template documents it.
+For future Vanilla blocktype/worldproperty authoring, the intended profile id is:
+
+    freven.vanilla:blocktypes_v1
+
+If the Vanilla profile is reported as unsupported, that means the schema is
+documented but the compiler is not available in the current DevKit build. Use
+the current canonical manifest workflow until the profile compiler lands.
+
+After compile/explain, validate the generated or existing canonical graph:
+
+    ./freven_boot content-assets check --instance <instance> --experience <experience_id>
+
+See [Content authoring profiles](CONTENT_AUTHORING_PROFILES.md).
+
 ## Modular content manifest include fails
 
 If a content/assets command reports a missing include, invalid include path,


### PR DESCRIPTION
## Summary

Documents the DevKit-facing workflow for game-owned content authoring profiles.

This connects the SDK profile boundary, Boot `content compile` command surface, and Vanilla's future `freven.vanilla:blocktypes_v1` workflow without implying that Vanilla's schema is engine-mandatory.

## What changed

- Added `docs/CONTENT_AUTHORING_PROFILES.md`.
- Explained canonical content graph vs game-owned authoring profiles.
- Documented `freven_boot content compile`.
- Documented the default `freven.core:canonical_manifest_v1` passthrough profile.
- Documented the intended Vanilla profile id: `freven.vanilla:blocktypes_v1`.
- Documented the target Vanilla-style layout:
  - `blocktypes/`
  - `worldproperties/`
  - `shapes/`
  - `textures/`
  - `tags/`
- Explained when to use low-level canonical manifests vs a game-owned profile.
- Added troubleshooting guidance for unknown/unsupported profile compile errors.
- Updated template/workflow/diagnostics/ownership docs to link the new profile guide.
- Clarified that this repo currently documents template contracts instead of adding fake checked-in templates.

## Validation

- git --no-pager diff --check
- markdown local link check
- coverage grep for content authoring profiles, `content compile`, `freven.core:canonical_manifest_v1`, `freven.vanilla:blocktypes_v1`, canonical content graph, blocktypes/worldproperties/shapes, Vanilla, Factorio, Minecraft, and unsupported-profile diagnostics

Closes frevenengine/freven-devkit#110
