### PR TITLE
Document Vanilla blocktype shape authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Include:
 - [Data/content asset workflow](docs/DATA_CONTENT_ASSET_WORKFLOW.md)
 - [Modular content authoring](docs/MODULAR_CONTENT_AUTHORING.md)
 - [Content authoring profiles](docs/CONTENT_AUTHORING_PROFILES.md)
+- [Vanilla blocktype modding](docs/VANILLA_BLOCKTYPE_MODDING.md)
 - [Asset pipeline diagnostics](docs/ASSET_PIPELINE_DIAGNOSTICS.md)
 - [Asset authoring templates](docs/ASSET_AUTHORING_TEMPLATES.md)
 - [Content family authoring](docs/CONTENT_FAMILY_AUTHORING.md)

--- a/docs/ASSET_AUTHORING_TEMPLATES.md
+++ b/docs/ASSET_AUTHORING_TEMPLATES.md
@@ -52,7 +52,7 @@ The script verifies:
 
 ## Modular template layout
 
-For larger templates and future Vanilla-style visual packs, use this layout:
+For larger templates and Vanilla-style visual packs, use this layout:
 
     content.manifest
     content/
@@ -78,7 +78,13 @@ The root manifest is an explicit index:
 Do not use directory scanning, generated cache, or renderer/internal ids as
 authoring template source. See [Modular content authoring](MODULAR_CONTENT_AUTHORING.md).
 
-When a selected game provides a higher-level authoring profile, template docs should name the profile id and explain the `freven_boot content compile` step. For Vanilla-style block authoring, the intended profile is `freven.vanilla:blocktypes_v1`; low-level visual templates may continue to use `freven.core:canonical_manifest_v1` directly. See [Content authoring profiles](CONTENT_AUTHORING_PROFILES.md).
+When a selected game provides a higher-level authoring profile, template docs should name the profile id and explain the `freven_boot content compile` step. For Vanilla-style block authoring, the profile is `freven.vanilla:blocktypes_v1`; low-level visual templates may continue to use `freven.core:canonical_manifest_v1` directly. See [Content authoring profiles](CONTENT_AUTHORING_PROFILES.md).
+
+## Vanilla blocktype template guidance
+
+Do not fake a checked-in Vanilla blocktype template in this repository unless the template catalog itself exists here. Packaged DevKit/Boot templates that target Vanilla-style blocks should document the profile id `freven.vanilla:blocktypes_v1`, include source files under `content/blocktypes/` and `content/shapes/`, and tell authors to run `freven_boot content compile` before `content-assets check`.
+
+For the copyable workflow, see [Vanilla blocktype modding](VANILLA_BLOCKTYPE_MODDING.md).
 
 ## Use a template
 

--- a/docs/CONTENT_AUTHORING_PROFILES.md
+++ b/docs/CONTENT_AUTHORING_PROFILES.md
@@ -92,7 +92,7 @@ Texture hash maintenance remains:
 
 ## Vanilla profile
 
-The intended Vanilla profile id is:
+The Vanilla profile id is:
 
     freven.vanilla:blocktypes_v1
 
@@ -137,9 +137,8 @@ That means:
 
 - `content/blocktypes/*.toml` in current Vanilla are semantic canonical source
   files;
-- future `freven.vanilla:blocktypes_v1` source may become higher level;
-- `freven_boot content compile --profile freven.vanilla:blocktypes_v1` is the
-  intended compiler bridge once the Vanilla compiler lands;
+- `freven.vanilla:blocktypes_v1` source is the high-level Vanilla blocktype path;
+- `freven_boot content compile --profile freven.vanilla:blocktypes_v1` compiles it into canonical generated output;
 - the engine should still only see the canonical content graph.
 
 ## Choosing the right layer
@@ -206,8 +205,8 @@ Example:
 
 Example unsupported profile:
 
-    error: content compile profile 'freven.vanilla:blocktypes_v1' is declared but not implemented yet
-    fix: use freven.core:canonical_manifest_v1 for current canonical manifests, or wait for the Vanilla profile compiler
+    error: duplicate generated key 'freven.vanilla:stone'
+    fix: rename one source `code` or generated target so each canonical key has one owner
 
 ## Relationship to templates
 
@@ -232,3 +231,4 @@ contract and point to the packaged DevKit/Boot template location.
 - [Project templates](PROJECT_TEMPLATES.md)
 - [Engine vs Vanilla ownership](ENGINE_VANILLA_OWNERSHIP.md)
 - [Troubleshooting](TROUBLESHOOTING.md)
+- [Vanilla blocktype modding](VANILLA_BLOCKTYPE_MODDING.md)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -154,3 +154,5 @@ On Windows, use `freven_boot.exe` with the same `providers` subcommands.
 
 See [Provider selection authoring](PROVIDER_AUTHORING.md) for the full provider
 key contract and side-aware validation rules.
+
+For Vanilla-style blocks, see [Vanilla blocktype modding](VANILLA_BLOCKTYPE_MODDING.md).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -104,11 +104,11 @@ Use the canonical passthrough profile for current low-level manifests:
     ./freven_boot content compile --instance <instance> --experience <experience_id> --profile freven.core:canonical_manifest_v1 --explain
 
 Use a game-owned profile only when the selected game or template documents it.
-For future Vanilla blocktype/worldproperty authoring, the intended profile id is:
+For Vanilla blocktype/worldproperty authoring, the profile id is:
 
     freven.vanilla:blocktypes_v1
 
-If the Vanilla profile is reported as unsupported, that means the schema is
+If the Vanilla profile is reported as unsupported, check that the selected DevKit/Boot build includes the Vanilla profile compiler. The schema is
 documented but the compiler is not available in the current DevKit build. Use
 the current canonical manifest workflow until the profile compiler lands.
 
@@ -229,3 +229,19 @@ Check:
 - generated visuals reference existing models and materials.
 
 See [Content family authoring](CONTENT_FAMILY_AUTHORING.md).
+
+## Vanilla blocktype compile generated the wrong collision or selection
+
+Vanilla visual model geometry and runtime shape semantics are separate.
+
+If a block looks correct but collision, selection, side solidity, or occlusion is
+wrong, edit the shape source fields used by `freven.vanilla:blocktypes_v1`:
+
+    occludes
+    side_solid
+    collision_boxes
+    selection_boxes
+
+Do not fix gameplay shape by changing renderer-only model `elements`.
+
+See [Vanilla blocktype modding](VANILLA_BLOCKTYPE_MODDING.md).

--- a/docs/VANILLA_BLOCKTYPE_MODDING.md
+++ b/docs/VANILLA_BLOCKTYPE_MODDING.md
@@ -1,0 +1,327 @@
+# Vanilla blocktype modding workflow
+
+Vanilla blocktype authoring is the friendly, game-owned path for adding or
+changing Vanilla-style blocks.
+
+Use this workflow when you want to author blocks in the Vanilla content style
+instead of writing the low-level canonical manifest graph by hand.
+
+The profile id is:
+
+    freven.vanilla:blocktypes_v1
+
+This profile is owned by Vanilla. It is not an engine-global schema. The engine
+and runtime consume the compiled canonical output, not the high-level Vanilla
+source files.
+
+## What this profile compiles
+
+Vanilla blocktype source compiles into the canonical content graph consumed by
+Boot, Engine, and the runtime:
+
+- textures;
+- materials;
+- models;
+- block visuals;
+- content families;
+- block tags;
+- block shapes.
+
+Block shapes are runtime semantics, not renderer geometry. They compile into
+canonical `[[block_shapes]]` declarations with:
+
+- `occludes`;
+- `side_solid`;
+- `collision_boxes`;
+- `selection_boxes`.
+
+Visual model `elements` describe how a block looks. They do not automatically
+define collision, selection, side solidity, or occlusion.
+
+In short: visual model `elements` do not automatically define collision.
+
+## Recommended source layout
+
+A Vanilla-style content layer should keep high-level source separate from
+generated canonical output:
+
+    content/
+      blocktypes/
+        my_block.toml
+      shapes/
+        block/
+          cube.toml
+      worldproperties/
+        rock.toml
+      _compiled/
+        vanilla_blocktypes_v1/
+          README.md
+          blocktypes/
+          families/
+      manifest.d/
+        compiled.generated.manifest
+      content.manifest
+
+The generated files are rebuildable output. Keep source files in
+`blocktypes/`, `shapes/`, and `worldproperties/` as the author-owned files.
+
+## Minimal cube block source
+
+A simple texture-backed cube blocktype looks like this:
+
+    profile = "freven.vanilla:blocktypes_v1"
+    kind = "cube_block"
+    code = "my_block"
+    title = "My Block"
+
+    shape = "freven.vanilla:shapes/block/cube"
+    texture = "freven.vanilla:textures/my_block"
+    material = "freven.vanilla:block/my_block"
+
+    render_layer = "opaque"
+    fallback_debug_tint_rgba = 2155905279
+
+    tags = [
+      "freven.vanilla:terrain",
+    ]
+
+The important long-term rules are:
+
+- `code` becomes the stable generated Vanilla block key suffix;
+- `texture` and `material` are stable namespaced content keys;
+- `shape` points at a Vanilla-owned high-level shape source;
+- `fallback_debug_tint_rgba` must match the generated material fallback tint;
+- do not author renderer internal slots or runtime ids.
+
+## Shape source semantics
+
+A full cube shape source declares both visual geometry and physical/query
+semantics.
+
+Example shape fields:
+
+    profile = "freven.vanilla:blocktypes_v1"
+    kind = "shape"
+    code = "block/cube"
+
+    material_slots = ["all"]
+
+    [[elements]]
+    from = [0.0, 0.0, 0.0]
+    to = [1.0, 1.0, 1.0]
+
+    [elements.faces]
+    all = "all"
+
+    [occludes]
+    bottom = true
+    top = true
+    north = true
+    south = true
+    east = true
+    west = true
+
+    [side_solid]
+    bottom = true
+    top = true
+    north = true
+    south = true
+    east = true
+    west = true
+
+    [[collision_boxes]]
+    min = [0.0, 0.0, 0.0]
+    max = [1.0, 1.0, 1.0]
+
+    [[selection_boxes]]
+    min = [0.0, 0.0, 0.0]
+    max = [1.0, 1.0, 1.0]
+
+Box coordinates are normalized block-space AABBs. Each axis must satisfy:
+
+    0.0 <= min < max <= 1.0
+
+Use explicit boxes even when the visual geometry looks like the same cube. That
+keeps future partial blocks, slabs, framed glass, foliage, and custom authored
+shapes honest.
+
+## Transparent blocks
+
+Transparent visual rendering does not mean empty collision.
+
+For example, glass can be:
+
+- visually transparent;
+- physically solid;
+- selectable as a full cube;
+- non-occluding for neighbor face culling.
+
+That means the material/render layer can be transparent while `collision_boxes`
+and `selection_boxes` still describe a full block. `occludes` can be false for
+all sides while `side_solid` remains true where gameplay needs a solid side.
+
+## Compile/check loop
+
+After editing Vanilla-style source, run the profile compiler:
+
+    freven_boot content compile \
+      --instance <instance> \
+      --experience <experience_id> \
+      --profile freven.vanilla:blocktypes_v1 \
+      --explain
+
+Then validate texture hashes and generated canonical content:
+
+    freven_boot content-assets check \
+      --instance <instance> \
+      --experience <experience_id>
+
+When texture bytes change, update hashes explicitly:
+
+    freven_boot content-assets update-sha \
+      --instance <instance> \
+      --experience <experience_id> \
+      --write
+
+Then check again:
+
+    freven_boot content-assets check \
+      --instance <instance> \
+      --experience <experience_id>
+
+## Inspect generated output
+
+Use the generated output as a diagnostic view, not as the primary authoring
+surface.
+
+Useful checks:
+
+    rg -n 'generated_from_profile|block_shapes|collision_boxes|selection_boxes|occludes|side_solid' \
+      <experience>/content/_compiled/vanilla_blocktypes_v1 \
+      <experience>/content/manifest.d
+
+    freven_boot content-assets inspect \
+      --instance <instance> \
+      --experience <experience_id> \
+      --kind generated
+
+The generated output should show canonical `[[block_shapes]]` declarations for
+authored blocktypes and families.
+
+## Launch validation
+
+After compile and asset checks pass, launch a visual validation or local
+instance:
+
+    freven_boot run client \
+      --instance <instance> \
+      --experience <experience_id>
+
+For Vanilla visual validation stacks, use the stack/experience id documented by
+the selected DevKit or Boot distribution.
+
+## When to use the low-level canonical graph
+
+Use `freven.core:canonical_manifest_v1` only when you intentionally want the
+low-level content graph:
+
+- reusable engine-neutral content packs;
+- custom non-Vanilla game content;
+- tests that need exact canonical declarations;
+- advanced debugging of generated output.
+
+For normal Vanilla-style blocks, use:
+
+    freven.vanilla:blocktypes_v1
+
+## Troubleshooting
+
+### Duplicate generated keys
+
+Symptom:
+
+    duplicate generated key
+
+Cause:
+
+    Two high-level source files compile to the same canonical key.
+
+Fix:
+
+    Rename one `code`, material key, texture key, family id, or generated target.
+    The diagnostic should point at both source files.
+
+### Unsupported field
+
+Symptom:
+
+    unknown field
+    unsupported field
+
+Cause:
+
+    The file is using a field that the selected profile schema does not own.
+
+Fix:
+
+    Check the selected profile. Vanilla blocktype source belongs to
+    `freven.vanilla:blocktypes_v1`; low-level canonical manifest fields belong
+    to `freven.core:canonical_manifest_v1`.
+
+### Missing texture hash
+
+Symptom:
+
+    missing sha256
+    sha256 mismatch
+
+Cause:
+
+    Texture bytes changed or a new texture was added without updating the
+    manifest hash.
+
+Fix:
+
+    freven_boot content-assets update-sha \
+      --instance <instance> \
+      --experience <experience_id> \
+      --write
+
+    freven_boot content-assets check \
+      --instance <instance> \
+      --experience <experience_id>
+
+### Unsupported profile
+
+Symptom:
+
+    unsupported content compile profile
+
+Cause:
+
+    The selected DevKit/Boot build does not include the requested profile, or
+    the command is being run against the wrong distribution.
+
+Fix:
+
+    Check the profile id and the selected DevKit/Boot version. Vanilla-style
+    blocktype authoring requires:
+
+        freven.vanilla:blocktypes_v1
+
+### Collision does not match visuals
+
+Symptom:
+
+    The block looks partial but collides or selects like a full cube, or the
+    reverse.
+
+Cause:
+
+    Visual `elements` and runtime `collision_boxes` / `selection_boxes` are
+    separate declarations.
+
+Fix:
+
+    Edit the shape source. Do not try to fix collision by changing renderer-only
+    model geometry.


### PR DESCRIPTION
## Summary

Documents the production Vanilla blocktype modding workflow now that `freven.vanilla:blocktypes_v1` compiles into canonical runtime block shape metadata.

## Details

- Adds a copyable Vanilla blocktype modding guide.
- Documents the `freven.vanilla:blocktypes_v1` compile path.
- Explains generated canonical `[[block_shapes]]` output:
  - `occludes`
  - `side_solid`
  - `collision_boxes`
  - `selection_boxes`
- Clarifies that visual model `elements` are render geometry, not collision/selection semantics.
- Documents transparent block behavior: transparent render layer can still be solid/selectable while non-occluding.
- Links the guide from README, getting started, content authoring profiles, asset templates, and troubleshooting.
- Replaces stale “future/intended/not implemented” wording with the current production workflow.

## Validation

- Docs invariant check for required Vanilla blocktype workflow terms
- stale future/not-implemented wording grep
- `git --no-pager diff --check`

Closes frevenengine/freven-devkit#112.